### PR TITLE
Begin basic script interacting with Slack API

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+TEAM_NAME=tech-team

--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+# .env -- We want to track our dotenv file in this project
 .venv
 env/
 venv/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,4 @@
+# Extra packages useful for developing the app
+#
+# rich for pretty printing json data
+rich==12.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# Packages required for running the app
+#
+# python-dotenv for reading in variables from a .env file
+python-dotenv==0.20.0
+
+# slack-sdk for interacting with the Slack API
+slack-sdk==3.15.2

--- a/src/app.py
+++ b/src/app.py
@@ -1,8 +1,9 @@
 import os
-from dotenv import load_dotenv
-from slack_sdk import WebClient
 from pathlib import Path
+
+from dotenv import load_dotenv
 from rich import print_json
+from slack_sdk import WebClient
 
 
 class TeamRolesGeekbotSweep:
@@ -16,7 +17,7 @@ class TeamRolesGeekbotSweep:
         self.team_name = os.getenv("TEAM_NAME")
 
         # Instantiate a SLACK API client
-        self.client = WebClient(token=os.environ['SLACK_BOT_TOKEN'])
+        self.client = WebClient(token=os.environ["SLACK_BOT_TOKEN"])
 
     def _get_team_id(self):
         # Get all usergroups in workspace
@@ -25,7 +26,11 @@ class TeamRolesGeekbotSweep:
         )
 
         # Find IDs for the self.team_name usergroup
-        index = next(idx for (idx, usergroup) in enumerate(response["usergroups"]) if usergroup["handle"] == self.team_name)
+        index = next(
+            idx
+            for (idx, usergroup) in enumerate(response["usergroups"])
+            if usergroup["handle"] == self.team_name
+        )
         self.usergroup_id = response["usergroups"][index]["id"]
         self.team_id = response["usergroups"][index]["team_id"]
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,68 @@
+import os
+from dotenv import load_dotenv
+from slack_sdk import WebClient
+from pathlib import Path
+from rich import print_json
+
+
+class TeamRolesGeekbotSweep:
+    def __init__(self):
+        # Load variables from a .env file
+        project_path = Path(__file__).parent.parent
+        dotenv_path = project_path.joinpath(".env")
+        load_dotenv(dotenv_path=dotenv_path)
+
+        # Set variables
+        self.team_name = os.getenv("TEAM_NAME")
+
+        # Instantiate a SLACK API client
+        self.client = WebClient(token=os.environ['SLACK_BOT_TOKEN'])
+
+    def _get_team_id(self):
+        # Get all usergroups in workspace
+        response = self.client.api_call(
+            api_method="usergroups.list",
+        )
+
+        # Find IDs for the self.team_name usergroup
+        index = next(idx for (idx, usergroup) in enumerate(response["usergroups"]) if usergroup["handle"] == self.team_name)
+        self.usergroup_id = response["usergroups"][index]["id"]
+        self.team_id = response["usergroups"][index]["team_id"]
+
+    def _get_user_ids(self):
+        # Find all user IDs in the self.team_name usergroup
+        response = self.client.api_call(
+            api_method="usergroups.users.list",
+            params={"usergroup": self.usergroup_id},
+        )
+        self.user_ids = response["users"]
+
+    def _convert_user_id_to_handle(self, user_id):
+        # Convert user IDs to 'real names', or 'display names' if available
+        response = self.client.api_call(
+            api_method="users.info",
+            params={"user": user_id},
+        )
+
+        username = response["user"]["profile"]["display_name"]
+        if username == "":
+            username = response["user"]["profile"]["real_name"]
+
+        return username
+
+    def get_users_in_team(self):
+        self._get_team_id()
+        self._get_user_ids()
+
+        user_handles = []
+        for user_id in self.user_ids:
+            user_handles.append(self._convert_user_id_to_handle(user_id))
+
+        return user_handles
+
+
+if __name__ == "__main__":
+    app = TeamRolesGeekbotSweep()
+    usernames = app.get_users_in_team()
+    print(f"Users in {app.team_name}:")
+    print_json(data=usernames)


### PR DESCRIPTION
- Adds basic package requirements
- Creates a `TeamRolesGeekbotSweep` class
  - Currently functionality is to return a list of Slack handles of members of a given team. E.g. input `tech-team` returns the Slack handles of the engineering team.