### PR TITLE
Update an existing standup instead of creating a new one

### DIFF
--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -53,6 +53,11 @@ class GeekbotStandup:
         return geekbot_session
 
     def _check_standup_exists(self):
+        """Check if the standup already exists. If it does, return its ID.
+
+        Returns:
+            int: The ID number of the standup, if it exists. None otherwise.
+        """
         response = self.geekbot_session.get(
             "/".join([self.geekbot_api_url, "v1", "standups"])
         )

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -72,16 +72,19 @@ class GeekbotStandup:
             dict: The metadata required to describe a new Geekbot standup
         """
         metadata = {
-            "name": self.standup_name,
-            "channel": self.broadcast_channel,
-            "time": "10:00:00",
-            "timezone": "",  # By leaving this blank it will trigger in user's timezone
             "wait_time": 10,
-            "days": [self.standup_day],
             "users": [self.roles["id"]],
             "sync_channel_members": False,
             "personalized": False,
         }
+
+        if not self.standup_exists:
+            metadata["name"] = self.standup_name
+            metadata["channel"] = self.broadcast_channel
+            metadata["days"] = [self.standup_day]
+            metadata["time"] = "10:00:00"
+            metadata["timezone"] = "user_local"
+
         return metadata
 
     def _generate_question_meeting_facilitator(self):

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -21,6 +21,11 @@ class GeekbotStandup:
         self.geekbot_api_url = "https://api.geekbot.io"
         self.geekbot_api_key = os.environ["GEEKBOT_API_KEY"]
 
+        try:
+            self.CI_env = os.environ["CI"]
+        except KeyError:
+            self.CI_env = False
+
         # Open a Geekbot session
         self.geekbot_session = self._create_geekbot_session()
 
@@ -162,7 +167,9 @@ class GeekbotStandup:
                 "/".join([self.geekbot_api_url, "v1", "standups"]), json=metadata
             )
 
-        print_json(data=response.json())
+        if not self.CI_env:
+            print_json(data=response.json())
+
         response.raise_for_status()
 
     def create_support_steward_standup(self):
@@ -190,7 +197,10 @@ class GeekbotStandup:
         response = self.geekbot_session.post(
             "/".join([self.geekbot_api_url, "v1", "standups"]), json=metadata
         )
-        print_json(data=response.json())
+
+        if not self.CI_env:
+            print_json(data=response.json())
+
         response.raise_for_status()
 
 


### PR DESCRIPTION
Whenever a new standup is created (at least in the dashboard), a message is sent to the broadcast channel and to the user who is assigned to the standup. To reduce the amount of noise this will generate, we will instead use the update method to update the existing one instead.

**To be investigated:**

- Will this approach **replace** the user who will receive a DM, or just **add** them? If they are added, we might need to use the replace method instead.