### PR TITLE
Improving the scripts

### DIFF
--- a/.github/workflows/populate-current-roles.yaml
+++ b/.github/workflows/populate-current-roles.yaml
@@ -23,6 +23,14 @@ on:
         default: tech-team
         description: |
           The Slack team our Team Roles are generated from
+      standup-manager:
+        required: false
+        default: "Sarah"
+        description: |
+          The Slack display name of the team member who will manage the standups.
+          They should have generated the API key saved in GEEKBOT_API_KEY.
+          This role is required so that the API can continue to 'see' all standups that
+          it has created.
 
 jobs:
   populate-team-roles:
@@ -51,6 +59,7 @@ jobs:
           CURRENT_SUPPORT_STEWARD: "${{ github.event.inputs.current-support-steward }}"
           INCOMING_SUPPORT_STEWARD: "${{ github.event.inputs.incoming-support-steward }}"
           TEAM_NAME: "${{ github.event.inputs.team-name }}"
+          STANDUP_MANAGER: "${{ github.event.inputs.standup-manager }}"
           SLACK_BOT_TOKEN: "${{ secrets.SLACK_BOT_TOKEN }}"
 
       - name: Add and Commit updated team-roles.json file

--- a/README.md
+++ b/README.md
@@ -36,8 +36,17 @@ This is because interacting with the APIs requires the user ID, but it is more h
 
 For the Support Steward, we track both the current and incoming team members as we have two people overlapping in this role.
 
+We have an extra role here called `standup_manager`.
+This is the team member who created `GEEKBOT_API_KEY` and will be added to all standups.
+This is because Geekbot only provide personal API keys and they do not have permission to see any standups the owner is not a member of.
+:fire: **If you are changing this role, you will need to recreate `GEEKBOT_API_KEY`.** :fire:
+
 ```json
 {
+    "standup_manager": {
+      "name": "display_name",
+      "id": "slack_id"
+    },
     "meeting_facilitator": {
         "name": "display_name",
         "id": "slack_id"
@@ -158,6 +167,9 @@ In addition to the two environment variables required by `get_slack_team_members
 - `CURRENT_MEETING_FACILITATOR`: The Slack display name of the team member currently serving in the Meeting Facilitator role
 - `CURRENT_SUPPORT_STEWARD`: The Slack display name of the team member currently serving in the Support Steward role (i.e. for more than two weeks)
 - `INCOMING_SUPPORT_STEWARD`: The Slack display name of the team member most recently taking up service in the Support Steward role (i.e. for less than two weeks)
+- `STANDUP_MANAGER`: This is the Slack display name of the team member who created `GEEKBOT_API_KEY` and will be added to all standups.
+  This role is required since Geekbot only offers personal API keys and the script won't be able to see any exisitng standups that the owner of the key is not a member of.
+  :fire: **If you are changing this role, you will need to recreate `GEEKBOT_API_KEY`.** :fire:
 
 This script is paired with the [`populate-current-roles` workflow](#populate-current-rolesyaml) to commit the updated `team-roles.json` file to the repo for future CI/CD runs of the bot.
 

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -108,7 +108,9 @@ class GeekbotStandup:
             "timezone": "user_local",
             "wait_time": 10,
             "days": [self.standup_day],
-            "users": [self.roles["id"]],
+            "users": [self.roles["id"]]
+            if self.roles["id"] == self.standup_manager["id"]
+            else [self.roles["id"], self.standup_manager["id"]],
             "sync_channel_members": False,
             "personalized": False,
         }
@@ -171,6 +173,7 @@ class GeekbotStandup:
         self.standup_name = "MeetingFacilitatorStandup"
         self.standup_day = "Mon"
         self.broadcast_channel = "#team-updates"
+        self.standup_manager = self.roles["standup_manager"]
         self.roles = self.roles["meeting_facilitator"]
 
         # First, check if a standup exists
@@ -191,8 +194,10 @@ class GeekbotStandup:
         response = self.geekbot_session.post(
             "/".join([self.geekbot_api_url, "v1", "standups"]), json=metadata
         )
+
         if not self.CI_env:
             print_json(data=response.json())
+
         response.raise_for_status()
 
     def create_support_steward_standup(self):
@@ -203,6 +208,7 @@ class GeekbotStandup:
         self.standup_name = "SupportStewardStandup"
         self.standup_day = "Wed"
         self.broadcast_channel = "#support-freshdesk"
+        self.standup_manager = self.roles["standup_manager"]
         self.steward_buddy = self.roles["support_steward"]["current"]["name"]
         self.roles = self.roles["support_steward"]["incoming"]
 

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -78,14 +78,14 @@ class GeekbotStandup:
         else:
             return None
 
+    def _delete_previous_standup(self, standup_id):
+        """Delete an existing Geekbot standup
 
-    def _delete_previous_standup(self):
+        Args:
+            standup_id (int): The ID of the standup to delete
         """
-        Delete an existing Geekbot standup
-        """
-        standup = self._get_standup()
         response = self.geekbot_session.delete(
-            "/".join([self.geekbot_api_url, "v1", "standups", standup["id"]])
+            "/".join([self.geekbot_api_url, "v1", "standups", str(standup_id)])
         )
 
         if not self.CI_env:
@@ -173,8 +173,12 @@ class GeekbotStandup:
         self.broadcast_channel = "#team-updates"
         self.roles = self.roles["meeting_facilitator"]
 
-        # First, delete previous standup
-        self._delete_previous_standup()
+        # First, check if a standup exists
+        standup_id = self._check_standup_exists()
+
+        if self.standup_exists:
+            # Delete the existing standup
+            self._delete_previous_standup(standup_id)
 
         # Generate metadata for the standup
         metadata = self._generate_standup_metadata()
@@ -202,8 +206,12 @@ class GeekbotStandup:
         self.steward_buddy = self.roles["support_steward"]["current"]["name"]
         self.roles = self.roles["support_steward"]["incoming"]
 
-        # First, delete previous standup
-        self._delete_previous_standup()
+        # First, check if a standup exists
+        standup_id = self._check_standup_exists()
+
+        if self.standup_exists:
+            # Delete the existing standup
+            self._delete_previous_standup(standup_id)
 
         # Generate metadata for the standup
         metadata = self._generate_standup_metadata()

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -139,7 +139,7 @@ class GeekbotStandup:
         Please make sure to watch for any incoming tickets here:
         https://2i2c.freshdesk.com/a/tickets/filters/all_tickets
         Reply 'ok' to this message to acknowledge your role. Or if you are going to be
-        away for a large part or your stewardship, please arrange cover with another
+        away for a large part of your stewardship, please arrange cover with another
         member of the Tech Team.
 
         Your support steward buddy is: {self.steward_buddy}

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 from pathlib import Path
+from textwrap import dedent
 
 from requests import Session
 from rich import print_json
@@ -13,7 +14,7 @@ from rich import print_json
 
 class GeekbotStandup:
     """
-    Mange Geekbot Standups in Slack for transitioning our Team Roles
+    Manage Geekbot Standups in Slack for transitioning our Team Roles
     """
 
     def __init__(self):
@@ -105,10 +106,11 @@ class GeekbotStandup:
         Returns:
             str: The question to be posed to the new Meeting Facilitator
         """
-        question = """
-        It is your turn to facilitate this month's team meeting! You can check the team
-        calendar for when this month's meeting is scheduled for here:
-        https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%%40group.calendar.google.com
+        question = dedent(f"""\
+        {self.roles['name'].split()[0]} - it is your turn to facilitate this month's
+        team meeting! You can check the team calendar for when this month's meeting is
+        scheduled for here:
+        https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com
         Reply 'ok' to this message to acknowledge your role. Or if you are not able to
         fulfil this role at this time, please arrange cover with another member of the
         Tech Team.
@@ -118,7 +120,7 @@ class GeekbotStandup:
         - Facilitate the meeting
         - Open up any follow-up issues or discussions and link to the hackmd
         - Transfer notes from the hackmd into the Team Compass
-        """
+        """)
         return question
 
     def _generate_question_support_steward(self):
@@ -129,15 +131,16 @@ class GeekbotStandup:
         Returns:
             str: The question to be posed to the new Support Steward
         """
-        question = f"""
-        It is your turn to be the support steward! Please make sure to watch for any
-        incoming tickets at https://2i2c.freshdesk.com/a/tickets/filters/all_tickets
+        question = dedent(f"""\
+        {self.roles['name'].split()[0]} - it is your turn to be the support steward!
+        Please make sure to watch for any incoming tickets here:
+        https://2i2c.freshdesk.com/a/tickets/filters/all_tickets
         Reply 'ok' to this message to acknowledge your role. Or if you are going to be
         away for a large part or your stewardship, please arrange cover with another
         member of the Tech Team.
 
         Your support steward buddy is: {self.steward_buddy}
-        """
+        """)
         return question
 
     def create_meeting_facilitator_standup(self):

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -106,7 +106,8 @@ class GeekbotStandup:
         Returns:
             str: The question to be posed to the new Meeting Facilitator
         """
-        question = dedent(f"""\
+        question = dedent(
+            f"""\
         {self.roles['name'].split()[0]} - it is your turn to facilitate this month's
         team meeting! You can check the team calendar for when this month's meeting is
         scheduled for here:
@@ -120,7 +121,8 @@ class GeekbotStandup:
         - Facilitate the meeting
         - Open up any follow-up issues or discussions and link to the hackmd
         - Transfer notes from the hackmd into the Team Compass
-        """)
+        """
+        )
         return question
 
     def _generate_question_support_steward(self):
@@ -131,7 +133,8 @@ class GeekbotStandup:
         Returns:
             str: The question to be posed to the new Support Steward
         """
-        question = dedent(f"""\
+        question = dedent(
+            f"""\
         {self.roles['name'].split()[0]} - it is your turn to be the support steward!
         Please make sure to watch for any incoming tickets here:
         https://2i2c.freshdesk.com/a/tickets/filters/all_tickets
@@ -140,7 +143,8 @@ class GeekbotStandup:
         member of the Tech Team.
 
         Your support steward buddy is: {self.steward_buddy}
-        """)
+        """
+        )
         return question
 
     def create_meeting_facilitator_standup(self):

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -89,7 +89,7 @@ class GeekbotStandup:
             "name": self.standup_name,
             "channel": self.broadcast_channel,
             "time": "10:00:00",
-            "timezone": "",  # By leaving this blank it will trigger in user's timezone
+            "timezone": "user_local",
             "wait_time": 10,
             "days": [self.standup_day],
             "users": [self.roles["id"]],

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -53,18 +53,31 @@ class GeekbotStandup:
         geekbot_session.headers.update({"Authorization": self.geekbot_api_key})
         return geekbot_session
 
-    def _get_standup(self):
-        """Retrieve information about an existing standup
+    def _check_standup_exists(self):
+        """Check if the standup already exists. Return it's ID if it does.
 
         Returns:
-            dict: Dictionary containing information about a chosen standup that exists
-                in Geekbot
+            int: ID of the existing standup
         """
         response = self.geekbot_session.get(
             "/".join([self.geekbot_api_url, "v1", "standups"])
         )
+
+        if not self.CI_env:
+            print_json(data=response.json())
+
         response.raise_for_status()
-        return next(x for x in response.json() if x["name"] == self.standup_name)
+
+        standup = next(
+            (x for x in response.json() if x["name"] == self.standup_name), None
+        )
+        self.standup_exists = bool(standup)
+
+        if self.standup_exists:
+            return standup["id"]
+        else:
+            return None
+
 
     def _delete_previous_standup(self):
         """

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -21,6 +21,11 @@ class GeekbotStandup:
         self.geekbot_api_url = "https://api.geekbot.io"
         self.geekbot_api_key = os.environ["GEEKBOT_API_KEY"]
 
+        try:
+            self.CI_env = os.environ["CI"]
+        except KeyError:
+            self.CI_env = False
+
         # Open a Geekbot session
         self.geekbot_session = self._create_geekbot_session()
 
@@ -159,7 +164,8 @@ class GeekbotStandup:
         response = self.geekbot_session.post(
             "/".join([self.geekbot_api_url, "v1", "standups"]), json=metadata
         )
-        print_json(data=response.json())
+        if not self.CI_env:
+            print_json(data=response.json())
         response.raise_for_status()
 
     def create_support_steward_standup(self):
@@ -187,7 +193,10 @@ class GeekbotStandup:
         response = self.geekbot_session.post(
             "/".join([self.geekbot_api_url, "v1", "standups"]), json=metadata
         )
-        print_json(data=response.json())
+
+        if not self.CI_env:
+            print_json(data=response.json())
+
         response.raise_for_status()
 
 

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -74,7 +74,10 @@ class GeekbotStandup:
         response = self.geekbot_session.delete(
             "/".join([self.geekbot_api_url, "v1", "standups", standup["id"]])
         )
-        print_json(data=response.json())
+
+        if not self.CI_env:
+            print_json(data=response.json())
+
         response.raise_for_status()
 
     def _generate_standup_metadata(self):

--- a/src/set_current_roles.py
+++ b/src/set_current_roles.py
@@ -17,6 +17,7 @@ def main():
     current_meeting_facilitator = os.environ["CURRENT_MEETING_FACILITATOR"]
     current_support_steward = os.environ["CURRENT_SUPPORT_STEWARD"]
     incoming_support_steward = os.environ["INCOMING_SUPPORT_STEWARD"]
+    standup_manager = os.environ["STANDUP_MANAGER"]
 
     # Instantiate SlackTeamMembers class
     slack = SlackTeamMembers()
@@ -24,6 +25,10 @@ def main():
 
     # Write team roles dict
     team_roles = {
+        "standup_manager": {
+            "name": standup_manager,
+            "id": members[standup_manager],
+        },
         "meeting_facilitator": {
             "name": current_meeting_facilitator,
             "id": members[current_meeting_facilitator],


### PR DESCRIPTION
Major changes:

- Ensure API responses are not printed when running in CI
- Check if a standup exists before continuing
- Include the "standup manager" role
  - Geekbot's API keys are personalised and so they cannot retrieve any standup they are not a member of. Defining this role allows the standups to be managed and rotated without constantly rotating `GEEKBOT_API_KEY` (though we should do that on a lower frequency)