### PR TITLE
Refining the standups

### DIFF
--- a/.github/workflows/create-standup-meeting-facilitator.yaml
+++ b/.github/workflows/create-standup-meeting-facilitator.yaml
@@ -18,40 +18,15 @@ on:
         description: |
           The Slack team our Team Roles are generated from
   schedule:
-    - cron: "0 0 * * 3"  # Run at 00:00 UTC every Wednesday (Because meetings happen Tuesdays)
+    - cron: "0 0 28 * *"  # Run at 00:00 UTC on the 28th) of each month
 
 env:
   TEAM_NAME: tech-team
 
 jobs:
-  is-four-weeks:
-    runs-on: ubuntu-latest
-    outputs:
-      continue-workflow: ${{ steps.decision.outputs.continue-workflow }}
-    steps:
-      - name: Decide if 4 weeks have passed and the workflow should continue
-        id: decision
-        shell: python
-        run: |
-          from datetime import date
-
-          # This is a Wednesday after our last team meeting (April 2022), so we'll
-          # calculate is_four_weeks relative to this
-          ref_date = date(2022, 4, 27)
-
-          diff_days = abs(date.today() - ref_date).days
-          n_days_since_last_meeting = diff_days % 28  # Because we have a meeting every 28 days
-          n_weeks_since_last_meeting = (n_days_since_last_meeting // 7) + 1  # Add 1 because we are effectively 0-indexed
-          is_four_weeks = (n_weeks_since_last_meeting % 4) == 0
-
-          # Set output variable for use in further jobs
-          print(f"::set-output name=continue-workflow::{is_four_weeks}")
-
   create-standup:
     runs-on: ubuntu-latest
     environment: run-slack-bot
-    needs: [is-four-weeks]
-    if: needs.is-four-weeks.outputs.continue-workflow == 'True' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/create-standup-meeting-facilitator.yaml
+++ b/.github/workflows/create-standup-meeting-facilitator.yaml
@@ -42,20 +42,20 @@ jobs:
           pip install poetry
           poetry install
 
-      - name: Update team member in role
-        if: github.event_name == 'schedule' || github.event.inputs.update-roles == 'true'
-        run: |
-          poetry run update-team-role meeting-facilitator
-        env:
-          TEAM_NAME: "${{ github.event.inputs.team-name || env.TEAM_NAME }}"
-          SLACK_BOT_TOKEN: "${{ secrets.SLACK_BOT_TOKEN }}"
+      # - name: Update team member in role
+      #   if: github.event_name == 'schedule' || github.event.inputs.update-roles == 'true'
+      #   run: |
+      #     poetry run update-team-role meeting-facilitator
+      #   env:
+      #     TEAM_NAME: "${{ github.event.inputs.team-name || env.TEAM_NAME }}"
+      #     SLACK_BOT_TOKEN: "${{ secrets.SLACK_BOT_TOKEN }}"
 
-      - name: Add and Commit updated team-roles.json file
-        if: github.event_name == 'schedule' || github.event.inputs.update-roles == 'true'
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: team-roles.json
-          message: "Update the Team Roles JSON file"
+      # - name: Add and Commit updated team-roles.json file
+      #   if: github.event_name == 'schedule' || github.event.inputs.update-roles == 'true'
+      #   uses: EndBug/add-and-commit@v9
+      #   with:
+      #     add: team-roles.json
+      #     message: "Update the Team Roles JSON file"
 
       - name: Create a standup for the Meeting Facilitator
         run: |

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -6,7 +6,6 @@ import argparse
 import json
 import os
 from pathlib import Path
-from textwrap import dedent
 
 from loguru import logger
 from requests import Session
@@ -118,22 +117,19 @@ class GeekbotStandup:
         """
         logger.info(f"Generating question for standup: {self.standup_name}")
 
-        question = dedent(
-            f"""\
-        {self.roles['name'].split()[0]} - it is your turn to facilitate this month's
-         team meeting! You can check the team calendar for when this month's meeting is
-         scheduled for here:
-         https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com
-         Reply 'ok' to this message to acknowledge your role. Or if you are not able to
-         fulfil this role at this time, please arrange cover with another member of the
-         Tech Team.
-
-        Here are some actions the meeting facilitator is expected to take:
-         - Collect and add agenda items to the meeting hackmd (link is in the calendar event)
-         - Facilitate the meeting
-         - Open up any follow-up issues or discussions and link to the hackmd
-         - Transfer notes from the hackmd into the Team Compass
-        """
+        question = (
+            f"{self.roles['name'].split()[0]} - it is your turn to facilitate this month's team meeting! "
+            + "You can check the team calendar for when this month's meeting is scheduled for here:\n"
+            + "https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com"
+            + "\n\n"
+            + "Reply 'ok' to this message to acknowledge your role. "
+            + "Or if you are not able to fulfil this role at this time, please arrange cover with another member of the Tech Team."
+            + "\n\n"
+            + "Here are some actions the meeting facilitator is expected to take:\n"
+            + ":white_check_mark: Collect and add agenda items to the meeting hackmd (link is in the calendar event)\n"
+            + ":white_check_mark: Facilitate the meeting\n"
+            + ":white_check_mark: Open up any follow-up issues or discussions and link to the hackmd\n"
+            + ":white_check_mark: Transfer notes from the hackmd into the Team Compass"
         )
         return question
 
@@ -147,17 +143,15 @@ class GeekbotStandup:
         """
         logger.info(f"Generating question for standup: {self.standup_name}")
 
-        question = dedent(
-            f"""\
-        {self.roles['name'].split()[0]} - it is your turn to be the support steward!
-         Please make sure to watch for any incoming tickets here:
-         https://2i2c.freshdesk.com/a/tickets/filters/all_tickets
-         Reply 'ok' to this message to acknowledge your role. Or if you are going to be
-         away for a large part of your stewardship, please arrange cover with another
-         member of the Tech Team.
-
-        Your support steward buddy is: {self.steward_buddy}
-        """
+        question = (
+            f"{self.roles['name'].split()[0]} - it is your turn to be the support steward! "
+            + "Please make sure to watch for any incoming tickets here:\n\n"
+            + "https://2i2c.freshdesk.com/a/tickets/filters/all_tickets"
+            + "\n\n"
+            + "Reply 'ok' to this message to acknowledge your role. "
+            + "Or if you are going to be away for a large part of your stewardship, please arrange cover with another member of the Tech Team."
+            + "\n\n"
+            + f"Your support steward buddy is: {self.steward_buddy.split()[0]}"
         )
         return question
 

--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -98,13 +98,20 @@ class GeekbotStandup:
             "time": "10:00:00",
             "timezone": "user_local",
             "wait_time": 10,
-            "days": [self.standup_day],
             "users": [self.roles["id"]]
             if self.roles["id"] == self.standup_manager["id"]
             else [self.roles["id"], self.standup_manager["id"]],
             "sync_channel_members": False,
             "personalized": False,
         }
+
+        if not self.standup_exists:
+            metadata["days"] = [self.standup_day]
+            logger.info(
+                f"This standup will be set to run **Weekly** on {self.standup_day}. "
+                + "Please edit the standup manually in the dashboard if you require a period other than Weekly."
+            )
+
         return metadata
 
     def _generate_question_meeting_facilitator(self):

--- a/team-roles.json
+++ b/team-roles.json
@@ -9,12 +9,12 @@
     },
     "support_steward": {
         "incoming": {
-            "name": "Georgiana",
-            "id": "U016E75LGH0"
+            "name": "Sarah",
+            "id": "U01G3RJP1U3"
         },
         "current": {
-            "name": "Erik Sundell",
-            "id": "U01742BQ99N"
+            "name": "Sarah",
+            "id": "U01G3RJP1U3"
         }
     }
 }


### PR DESCRIPTION
- Update question formatting
- Update when standup day is set
  - Only set standup day if standup is being newly created. Setting a standup day will automatically set the period to "weekly" and not respect any previous settings.
  - Add a logging note about updating the standup period manually if something other than weekly is required. Period cannot be set through the API.
- Pin all team roles to me for now for testing
- Simplify CI/CD workflow to create the meeting facilitator standup
  - Commit to running the workflow to the 28th of every month. The standup will notify the user on the first Monday of every month.
  - Disable updating the team roles for now.