### PR TITLE
Return to using the update method instead of replace

### DIFF
--- a/src/create_geekbot_standup.py
+++ b/src/create_geekbot_standup.py
@@ -192,6 +192,10 @@ class GeekbotStandup:
             response = self.geekbot_session.post(
                 "/".join([self.geekbot_api_url, "v1", "standups"]), json=metadata
             )
+            logger.info(
+                f"This standup will be set to run **Weekly** on {self.standup_day}. "
+                + "Please edit the standup manually in the dashboard if you require a period other than Weekly."
+            )
 
         if not self.CI_env:
             print_json(data=response.json())
@@ -232,6 +236,10 @@ class GeekbotStandup:
             logger.info(f"Creating a new standup: {self.standup_name}")
             response = self.geekbot_session.post(
                 "/".join([self.geekbot_api_url, "v1", "standups"]), json=metadata
+            )
+            logger.info(
+                f"This standup will be set to run **Weekly** on {self.standup_day}. "
+                + "Please edit the standup manually in the dashboard if you require a period other than Weekly."
             )
 
         if not self.CI_env:


### PR DESCRIPTION
Using replace, I was finding the schedule was being reset. Now that we have a standup manager role that will always be in the standups, I'm less nervous about creating runaway bots that I can longer control (although this is totally a villainous queen life goal of mine - just not at work), and so we switch back to using the update method in order to preserve the schedules.