### PR TITLE
Fix workflows for updating team roles

### DIFF
--- a/.github/workflows/create-standup-meeting-facilitator.yaml
+++ b/.github/workflows/create-standup-meeting-facilitator.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Update team member in role
         if: github.event_name == 'schedule' || github.event.inputs.update-roles == 'true'
         run: |
-          poetry run update-team-role meeting-facilitator
+          poetry run update-team-roles meeting-facilitator
           git diff
         env:
           TEAM_NAME: "${{ github.event.inputs.team-name || env.TEAM_NAME }}"


### PR DESCRIPTION
- Remove everything I added for debugging
- Fix typo in script name

I would've expected poetry to throw an error when trying to call a console entrypoint that didn't exist...