### PR TITLE
Add code for generating Calendar Events for Team Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,93 @@ To execute this script, run:
 poetry run populate-current-roles
 ```
 
+### `create_events_rolling_update.py`
+
+This script is used to create the next event for a Team Role given that a series of events already exist in a Google Calendar.
+It calculates the required metadata for the new event from the last event available on the calendar.
+It depends upon [`get_slack_team_members.py`](#get_slack_team_memberspy) to get an ordered list of the team members who fulfil these roles.
+
+In addition to the two environment variables required be `get_slack_team_members.py`, this script also requires the following environment variables to be set:
+
+- `GCP_SERVICE_ACCOUNT_KEY`: A Google Cloud Service Account with permissions to access Google's Calendar API
+- `CALENDAR_ID`: The ID of a Google Calendar to which the above Service Account has permission to manage events
+
+**Command line usage:**
+
+To execute this script, run:
+
+```bash
+poetry run create-next-event { meeting-facilitator | support-steward }
+```
+
+Help info:
+
+```bash
+usage: create-next-event [-h] {meeting-facilitator,support-steward}
+
+Create the next event in a series for a Team Role in a Google Calendar
+
+positional arguments:
+  {meeting-facilitator,support-steward}
+                        The role to create an event for
+
+optional arguments:
+  -h, --help            show this help message and exit
+```
+
+### `create_events_bulk.py`
+
+This script is used to generate a large number of events for a Team Role in a Google Calendar in bulk.
+It begins generating events either from the day the script is executed or from a provided reference date.
+It depends upon [`get_slack_team_members.py`](#get_slack_team_memberspy) to get an ordered list of the team members who fulfil these roles.
+
+In addition to the two environment variables required be `get_slack_team_members.py`, this script also requires the following environment variables to be set:
+
+- `GCP_SERVICE_ACCOUNT_KEY`: A Google Cloud Service Account with permissions to access Google's Calendar API
+- `CALENDAR_ID`: The ID of a Google Calendar to which the above Service Account has permission to manage events
+
+#### :fire: Reference Dates for the Support Steward :fire:
+
+Our Support Steward role starts and ends on Wednesdays for a period of 4 weeks with a team member rotating on/off the role every two weeks.
+
+The `create_events_bulk.py` script accounts for this by adjusting the reference date to the next Wednesday in the calendar.
+However, the next Wednesday might not necessarily line up with the 2/4 weekly cycle of the Support Steward.
+So take caution when running this script and choose a reference date carefully before executing.
+
+The two `create_events_*.py` scripts can't delete events and so, if they are repeatedly run, will create duplicate events.
+
+**Command line usage:**
+
+To execute this script, run:
+
+```bash
+poetry run create-bulk-events { meeting-facilitator | support-steward }
+```
+
+**Help info:**
+
+```bash
+usage: create-bulk-events [-h] [-n N_EVENTS] [-d DATE] {meeting-facilitator,support-steward}
+
+Bulk create a series of Team Role events in a Google Calendar
+
+positional arguments:
+  {meeting-facilitator,support-steward}
+                        The role to create events for
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -n N_EVENTS, --n-events N_EVENTS
+                        The number of role events to create. Defaults to 12 for Meeting
+                        Facilitator and 26 for Support Steward (both 1 year's worth).
+  -d DATE, --date DATE  A reference date to begin creating events from. Defaults to today.
+                        WARNING: EXPERIMENTAL FEATURE.
+```
+
+### `gcal_api_auth.py`
+
+This script is a helper script that returns an authenticated instance of the Google Calendar API for the [`create_events_rolling_update.py`](#create_events_rolling_updatepy) and [`create_events_bulk.py`](#create_events_bulkpy) to create events in a Google Calendar.
+
 ## CI/CD workflows
 
 All our CI/CD workflows are powered by [GitHub Actions](https://docs.github.com/en/actions) and the configuration is located in the [`.github/workflows`](.github/workflows/) folder.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ list-team-members = "src.geekbot.get_slack_team_members:main"
 update-team-role = "src.geekbot.update_team_roles:main"
 create-standup = "src.geekbot.create_geekbot_standup:main"
 populate-current-roles = "src.geekbot.set_current_roles:main"
+create-next-event = "src.calendar.create_events_rolling_update:main"
+create-bulk-events = "src.calendar.create_events_bulk:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ slack-sdk = "^3.15"
 requests = "^2.27"
 rich = "^12.3"
 loguru = "^0.6"
+python-dateutil = "^2.8"
+google-api-python-client = "^2.51"
+google-auth-httplib2 = "^0.1"
+google-auth-oauthlib = "^0.5"
 
 [tool.poetry.scripts]
 list-team-members = "src.geekbot.get_slack_team_members:main"

--- a/src/calendar/create_events_bulk.py
+++ b/src/calendar/create_events_bulk.py
@@ -162,21 +162,32 @@ class CreateBulkEvents:
         except HttpError as error:
             print(f"An error occured: {error}")
 
-    def create_bulk_events(self, role, n_events=None):
+    def create_bulk_events(self, role, name=None, n_events=None):
         """Bulk create Team Role events in a Google Calendar
 
         Args:
             role (str): The role to create events for. Either 'meeting-facilitator' or
                 'support-steward'.
+            name (str, optional): The name of the current team member serving in the
+                role. Defaults to None, and will be pulled from team-roles.json.
             n_events (int, optional): The number of events to create for the specified
                 role. Defaults to ROLE_CYCLES[role]["n_events"].
         """
-        # Find the name of the person currently serving in this role from team-roles.json
+        # Find the name of the person currently serving in this role from
+        # team-roles.json or use a provided 'name' variable
         if role == "meeting-facilitator":
-            current_member = self.team_roles[role.replace("-", "_")]["name"]
+            current_member = (
+                self.team_roles[role.replace("-", "_")]["name"]
+                if name is None
+                else name
+            )
         elif role == "support-steward":
             self._adjust_reference_date()
-            current_member = self.team_roles[role.replace("-", "_")]["current"]["name"]
+            current_member = (
+                self.team_roles[role.replace("-", "_")]["current"]["name"]
+                if name is None
+                else name
+            )
 
         # Find the index of the current team member in the ordered list
         current_member_index = list(self.team_members).index(current_member)
@@ -212,6 +223,13 @@ def main():
         help="The role to create events for",
     )
     parser.add_argument(
+        "-m",
+        "--team-member",
+        type=str,
+        default=None,
+        help="The name of the team member currently serving in the role. Will be pulled from team-roles.json if not provided.",
+    )
+    parser.add_argument(
         "-n",
         "--n-events",
         type=int,
@@ -222,6 +240,7 @@ def main():
         "-d",
         "--date",
         type=str,
+        default=None,
         help="A reference date to begin creating events from. Defaults to today. WARNING: EXPERIMENTAL FEATURE.",
     )
 

--- a/src/calendar/create_events_bulk.py
+++ b/src/calendar/create_events_bulk.py
@@ -1,3 +1,6 @@
+"""
+Create Team Role Events in a Calendar in bulk
+"""
 import argparse
 import json
 import os
@@ -11,23 +14,26 @@ from googleapiclient.errors import HttpError
 from ..geekbot.get_slack_team_members import SlackTeamMembers
 from .gcal_api_auth import GoogleCalendarAPI
 
+# Some information about how often each of our team roles is transferred
 ROLE_CYCLES = {
     "meeting-facilitator": {
         "unit": "months",
         "frequency": 1,  # Monthly
         "period": 1,
-        "n_cycles": 12,  # Equates to 1 year
+        "n_events": 12,  # Equates to 1 year
     },
     "support-steward": {
         "unit": "days",
         "frequency": 14,  # Fortnightly
         "period": 28,  # 4 weeks
-        "n_cycles": 26,  # Equates to 1 year
+        "n_events": 26,  # Equates to 1 year
     },
 }
 
 
 class CreateBulkEvents:
+    """Create Team Role events in a Calendar in Bulk"""
+
     def __init__(self, date=None):
         self.calendar_id = os.environ["CALENDAR_ID"]
         self._generate_reference_date(date=date)
@@ -40,12 +46,25 @@ class CreateBulkEvents:
             self.team_roles = json.load(stream)
 
     def _generate_reference_date(self, date=None):
+        """Generate a reference date to calculate start and end dates for role events
+        from. Defaults to the on which the program is run.
+
+        Args:
+            date (str, optional): A chosen reference date as a string in the format
+                'YYYY-MM-DD'. Defaults to None.
+        """
         if date is None:
             self.reference_date = datetime.today()
         else:
             self.reference_date = datetime.strptime(date, "%Y-%m-%d")
 
     def _adjust_reference_date(self):
+        """
+        The Support Steward Role is transferred on Wednesdays. We adjust the reference
+        date to be the next Wednesday from the given date for the calculations.
+        """
+        # isoweekday() returns an integer representation of the day of the week where
+        # MONDAY is 1 and SUNDAY is 7. Hence, WEDNESDAY is 3.
         weekday_num = self.reference_date.isoweekday()
 
         if weekday_num < 3:
@@ -58,6 +77,17 @@ class CreateBulkEvents:
             )
 
     def _calculate_event_dates_meeting_facilitator(self, offset):
+        """Calculate the start and end dates for a Meeting Facilitator calendar event
+
+        Args:
+            offset (int): The offset from the current date in months
+
+        Returns:
+            datetime objs: The start and end dates for a Meeting Facilitator event
+        """
+        # Always calculate the start date for the next month from the reference date
+        # given. Hence if offset = 0, we don't create a Meeting Facilitator event for
+        # the month we are currently in.
         start_date = self.reference_date + relativedelta(
             months=ROLE_CYCLES["meeting-facilitator"]["frequency"] * offset + 1
         )
@@ -65,13 +95,23 @@ class CreateBulkEvents:
             months=ROLE_CYCLES["meeting-facilitator"]["period"]
         )
 
+        # Meeting Facilitator events last the whole month, so ensure the day attribute
+        # is set to the first day of the month. End date is exclusive, so this will
+        # always run the end of the month, no matter how many days it contains.
         start_date = start_date.replace(day=1)
         end_date = end_date.replace(day=1)
 
         return start_date, end_date
 
     def _calculate_event_dates_support_steward(self, offset):
+        """Calculate the start and end dates for a Support Steward calendar event
 
+        Args:
+            offset (int): The offset from the current date in fortnights (2 weeks)
+
+        Returns:
+            datetime objs: The start and end dates for a Support Steward event
+        """
         start_date = self.reference_date + timedelta(
             days=(ROLE_CYCLES["support-steward"]["frequency"] * offset)
         )
@@ -82,6 +122,16 @@ class CreateBulkEvents:
         return start_date, end_date
 
     def _create_event(self, role, name, offset):
+        """Create an event in a Google Calendar
+
+        Args:
+            role (str): The role to create an event for. Either 'meeting-facilitator'
+                or 'support-steward'.
+            name (str): The name of the team member who will serve in this role for
+                this event
+            offset (int): The offset from the reference date. The units of this value
+                is described by ROLE_CYCLES[role]["units"].
+        """
         if role == "meeting-facilitator":
             start_date, end_date = self._calculate_event_dates_meeting_facilitator(
                 offset
@@ -89,6 +139,8 @@ class CreateBulkEvents:
         elif role == "support-steward":
             start_date, end_date = self._calculate_event_dates_support_steward(offset)
 
+        # This represents the minimum amount of information to POST to the Google
+        # Calendar API to create an event in a given calendar.
         body = {
             "summary": f"{' '.join(role.split('-')).title()}: {name.split()[0]}",
             "start": {
@@ -102,62 +154,81 @@ class CreateBulkEvents:
         }
 
         try:
+            # Create the event
             self.gcal_api.events().insert(
                 calendarId=self.calendar_id, body=body
             ).execute()
+
         except HttpError as error:
             print(f"An error occured: {error}")
 
-    def create_bulk_events(self, role, n_cycles=None):
+    def create_bulk_events(self, role, n_events=None):
+        """Bulk create Team Role events in a Google Calendar
+
+        Args:
+            role (str): The role to create events for. Either 'meeting-facilitator' or
+                'support-steward'.
+            n_events (int, optional): The number of events to create for the specified
+                role. Defaults to ROLE_CYCLES[role]["n_events"].
+        """
+        # Find the name of the person currently serving in this role from team-roles.json
         if role == "meeting-facilitator":
             current_member = self.team_roles[role.replace("-", "_")]["name"]
         elif role == "support-steward":
             self._adjust_reference_date()
             current_member = self.team_roles[role.replace("-", "_")]["current"]["name"]
+
+        # Find the index of the current team member in the ordered list
         current_member_index = list(self.team_members).index(current_member)
 
-        if n_cycles is None:
-            n_cycles = ROLE_CYCLES[role]["n_cycles"]
+        # Set the number of events to create if not specified
+        if n_events is None:
+            n_events = ROLE_CYCLES[role]["n_events"]
 
+        # Create a repeating list of team members (in order) long enough to index for
+        # the number of events we will create
         team_members = list(
             islice(
                 cycle(self.team_members),
                 current_member_index + 1,
-                n_cycles + current_member_index + 1,
+                n_events + current_member_index + 1,
             )
         )
 
-        for i in range(n_cycles):
+        # Create the events
+        for i in range(n_events):
             next_team_member = team_members[i]
             self._create_event(role, next_team_member, i)
 
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Bulk create a series of Team Role events in a Google Calendar"
+    )
 
     parser.add_argument(
         "role",
         choices=["meeting-facilitator", "support-steward"],
-        help="",
+        help="The role to create events for",
     )
     parser.add_argument(
         "-n",
-        "--n-cycles",
+        "--n-events",
         type=int,
         default=None,
-        help="",
+        help="The number of role events to create. Defaults to 12 for Meeting Facilitator and 26 for Support Steward (both 1 year's worth).",
     )
     parser.add_argument(
         "-d",
         "--date",
         type=str,
-        help="",
+        help="A reference date to begin creating events from. Defaults to today. WARNING: EXPERIMENTAL FEATURE.",
     )
 
     args = parser.parse_args()
 
     create_bulk_events = CreateBulkEvents(date=args.date)
-    create_bulk_events.create_bulk_events(args.role, n_cycles=args.n_cycles)
+    create_bulk_events.create_bulk_events(args.role, n_events=args.n_events)
 
 
 if __name__ == "__main__":

--- a/src/calendar/create_events_bulk.py
+++ b/src/calendar/create_events_bulk.py
@@ -8,10 +8,8 @@ from pathlib import Path
 from dateutil.relativedelta import relativedelta
 from googleapiclient.errors import HttpError
 
-from src.calendar.gcal_api_auth import GoogleCalendarAPI
-from src.geekbot.get_slack_team_members import SlackTeamMembers
-
-ROOT_DIR = Path(__file__).parent.parent.parent
+from .gcal_api_auth import GoogleCalendarAPI
+from ..geekbot.get_slack_team_members import SlackTeamMembers
 
 ROLE_CYCLES = {
     "meeting-facilitator": {
@@ -36,7 +34,8 @@ class CreateBulkEvents:
         self.team_members = SlackTeamMembers().get_users_in_team().keys()
         self.gcal_api = GoogleCalendarAPI().authenticate()
 
-        team_roles_path = ROOT_DIR.joinpath("team-roles.json")
+        project_path = Path(__file__).parent.parent.parent
+        team_roles_path = project_path.joinpath("team-roles.json")
         with open(team_roles_path) as stream:
             self.team_roles = json.load(stream)
 

--- a/src/calendar/create_events_bulk.py
+++ b/src/calendar/create_events_bulk.py
@@ -1,0 +1,165 @@
+import argparse
+import json
+import os
+from datetime import datetime, timedelta
+from itertools import cycle, islice
+from pathlib import Path
+
+from dateutil.relativedelta import relativedelta
+from googleapiclient.errors import HttpError
+
+from src.calendar.gcal_api_auth import GoogleCalendarAPI
+from src.geekbot.get_slack_team_members import SlackTeamMembers
+
+ROOT_DIR = Path(__file__).parent.parent.parent
+
+ROLE_CYCLES = {
+    "meeting-facilitator": {
+        "unit": "months",
+        "frequency": 1,  # Monthly
+        "period": 1,
+        "n_cycles": 12,  # Equates to 1 year
+    },
+    "support-steward": {
+        "unit": "days",
+        "frequency": 14,  # Fortnightly
+        "period": 28,  # 4 weeks
+        "n_cycles": 26,  # Equates to 1 year
+    },
+}
+
+
+class CreateBulkEvents:
+    def __init__(self, date=None):
+        self.calendar_id = os.environ["CALENDAR_ID"]
+        self._generate_reference_date(date=date)
+        self.team_members = SlackTeamMembers().get_users_in_team().keys()
+        self.gcal_api = GoogleCalendarAPI().authenticate()
+
+        team_roles_path = ROOT_DIR.joinpath("team-roles.json")
+        with open(team_roles_path) as stream:
+            self.team_roles = json.load(stream)
+
+    def _generate_reference_date(self, date=None):
+        if date is None:
+            self.reference_date = datetime.today()
+        else:
+            self.reference_date = datetime.strptime(date, "%Y-%m-%d")
+
+    def _adjust_reference_date(self):
+        weekday_num = self.reference_date.isoweekday()
+
+        if weekday_num < 3:
+            self.reference_date = self.reference_date + timedelta(
+                days=(3 - weekday_num)
+            )
+        elif weekday_num > 3:
+            self.reference_date = self.reference_date + timedelta(
+                days=(7 + (3 - weekday_num))
+            )
+
+    def _calculate_event_dates_meeting_facilitator(self, offset):
+        start_date = self.reference_date + relativedelta(
+            months=ROLE_CYCLES["meeting-facilitator"]["frequency"] * offset + 1
+        )
+        end_date = start_date + relativedelta(
+            months=ROLE_CYCLES["meeting-facilitator"]["period"]
+        )
+
+        start_date = start_date.replace(day=1)
+        end_date = end_date.replace(day=1)
+
+        return start_date, end_date
+
+    def _calculate_event_dates_support_steward(self, offset):
+
+        start_date = self.reference_date + timedelta(
+            days=(ROLE_CYCLES["support-steward"]["frequency"] * offset)
+        )
+        end_date = start_date + timedelta(
+            days=(ROLE_CYCLES["support-steward"]["period"])
+        )
+
+        return start_date, end_date
+
+    def _create_event(self, role, name, offset):
+        if role == "meeting-facilitator":
+            start_date, end_date = self._calculate_event_dates_meeting_facilitator(
+                offset
+            )
+        elif role == "support-steward":
+            start_date, end_date = self._calculate_event_dates_support_steward(offset)
+
+        body = {
+            "summary": f"{' '.join(role.split('-')).title()}: {name.split()[0]}",
+            "start": {
+                "date": start_date.strftime("%Y-%m-%d"),
+                "timeZone": "Etc/UTC",
+            },
+            "end": {
+                "date": end_date.strftime("%Y-%m-%d"),
+                "timeZone": "Etc/UTC",
+            },
+        }
+
+        try:
+            self.gcal_api.events().insert(
+                calendarId=self.calendar_id, body=body
+            ).execute()
+        except HttpError as error:
+            print(f"An error occured: {error}")
+
+    def create_bulk_events(self, role, n_cycles=None):
+        if role == "meeting-facilitator":
+            current_member = self.team_roles[role.replace("-", "_")]["name"]
+        elif role == "support-steward":
+            self._adjust_reference_date()
+            current_member = self.team_roles[role.replace("-", "_")]["current"]["name"]
+        current_member_index = list(self.team_members).index(current_member)
+
+        if n_cycles is None:
+            n_cycles = ROLE_CYCLES[role]["n_cycles"]
+
+        team_members = list(
+            islice(
+                cycle(self.team_members),
+                current_member_index + 1,
+                n_cycles + current_member_index + 1,
+            )
+        )
+
+        for i in range(n_cycles):
+            next_team_member = team_members[i]
+            self._create_event(role, next_team_member, i)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "role",
+        choices=["meeting-facilitator", "support-steward"],
+        help="",
+    )
+    parser.add_argument(
+        "-n",
+        "--n-cycles",
+        type=int,
+        default=None,
+        help="",
+    )
+    parser.add_argument(
+        "-d",
+        "--date",
+        type=str,
+        help="",
+    )
+
+    args = parser.parse_args()
+
+    create_bulk_events = CreateBulkEvents(date=args.date)
+    create_bulk_events.create_bulk_events(args.role, n_cycles=args.n_cycles)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/calendar/create_events_bulk.py
+++ b/src/calendar/create_events_bulk.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from dateutil.relativedelta import relativedelta
 from googleapiclient.errors import HttpError
 
-from .gcal_api_auth import GoogleCalendarAPI
 from ..geekbot.get_slack_team_members import SlackTeamMembers
+from .gcal_api_auth import GoogleCalendarAPI
 
 ROLE_CYCLES = {
     "meeting-facilitator": {

--- a/src/calendar/create_events_rolling_update.py
+++ b/src/calendar/create_events_rolling_update.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 from googleapiclient.errors import HttpError
 
-from src.calendar.gcal_api_auth import GoogleCalendarAPI
-from src.geekbot.get_slack_team_members import SlackTeamMembers
+from .gcal_api_auth import GoogleCalendarAPI
+from ..geekbot.get_slack_team_members import SlackTeamMembers
 
 ROLE_CYCLES = {
     "meeting-facilitator": {

--- a/src/calendar/create_events_rolling_update.py
+++ b/src/calendar/create_events_rolling_update.py
@@ -1,12 +1,12 @@
-import os
 import argparse
+import os
 from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
 from googleapiclient.errors import HttpError
 
-from .gcal_api_auth import GoogleCalendarAPI
 from ..geekbot.get_slack_team_members import SlackTeamMembers
+from .gcal_api_auth import GoogleCalendarAPI
 
 ROLE_CYCLES = {
     "meeting-facilitator": {

--- a/src/calendar/create_events_rolling_update.py
+++ b/src/calendar/create_events_rolling_update.py
@@ -1,0 +1,138 @@
+import os
+import argparse
+from datetime import datetime, timedelta
+
+from dateutil.relativedelta import relativedelta
+from googleapiclient.errors import HttpError
+
+from src.calendar.gcal_api_auth import GoogleCalendarAPI
+from src.geekbot.get_slack_team_members import SlackTeamMembers
+
+ROLE_CYCLES = {
+    "meeting-facilitator": {
+        "unit": "months",
+        "frequency": 1,  # Monthly
+        "period": 1,
+        "n_cycles": 12,  # Equates to 1 year
+    },
+    "support-steward": {
+        "unit": "days",
+        "frequency": 14,  # Fortnightly
+        "period": 28,  # 4 weeks
+        "n_cycles": 26,  # Equates to 1 year
+    },
+}
+
+
+class CreateNextEvent:
+    def __init__(self):
+        self.calendar_id = os.environ["CALENDAR_ID"]
+        self.gcal_api = GoogleCalendarAPI().authenticate()
+        self.team_members = SlackTeamMembers().get_users_in_team().keys()
+
+        self._get_todays_date()
+
+    def _get_todays_date(self):
+        self.today = datetime.utcnow()
+
+    def _get_upcoming_events(self, role):
+        events_results = (
+            self.gcal_api.events()
+            .list(
+                calendarId=self.calendar_id,
+                timeMin=self.today.isoformat() + "Z",
+                maxResults=100,
+                singleEvents=True,
+                orderBy="startTime",
+            )
+            .execute()
+        )
+
+        events = events_results.get("items", [])
+        events = [
+            event
+            for event in events
+            if " ".join(role.split("-")).title() in event["summary"]
+        ]
+
+        return events
+
+    def _calculate_next_event_data(self, role):
+        events = self._get_upcoming_events(role)
+
+        if role == "meeting-facilitator":
+            last_event = events[-1]
+        elif role == "support-steward":
+            last_event = events[-2]
+
+        last_event_end_date = last_event.get("dateTime", last_event["end"].get("date"))
+        last_event_end_date = datetime.strptime(last_event_end_date, "%Y-%m-%d")
+        last_team_member = last_event.get("summary", "").split(":")[-1].strip()
+
+        last_team_member_index = next(
+            (
+                i
+                for (i, name) in enumerate(self.team_members)
+                if last_team_member in name
+            ),
+            None,
+        )
+        next_team_member_index = last_team_member_index + 1
+
+        if next_team_member_index >= len(self.team_members):
+            next_team_member_index = 0
+
+        next_team_member = list(self.team_members)[next_team_member_index]
+
+        next_event_start_date = last_event_end_date
+
+        if role == "meeting-facilitator":
+            next_event_end_date = next_event_start_date + relativedelta(
+                months=ROLE_CYCLES[role]["period"]
+            )
+        elif role == "support-steward":
+            next_event_end_date = next_event_start_date + timedelta(
+                days=ROLE_CYCLES[role]["period"]
+            )
+
+        return next_event_start_date, next_event_end_date, next_team_member
+
+    def create_next_event(self, role):
+        start_date, end_date, name = self._calculate_next_event_data(role)
+
+        body = {
+            "summary": f"{' '.join(role.split('-')).title()}: {name}",
+            "start": {
+                "date": start_date.strftime("%Y-%m-%d"),
+                "timeZone": "Etc/UTC",
+            },
+            "end": {
+                "date": end_date.strftime("%Y-%m-%d"),
+                "timeZone": "Etc/UTC",
+            },
+        }
+
+        try:
+            self.gcal_api.events().insert(
+                calendarId=self.calendar_id, body=body
+            ).execute()
+        except HttpError as error:
+            print(f"An error occured: {error}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "role",
+        choices=["meeting-facilitator", "support-steward"],
+        help="",
+    )
+
+    args = parser.parse_args()
+
+    CreateNextEvent().create_next_event(role=args.role)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/calendar/gcal_api_auth.py
+++ b/src/calendar/gcal_api_auth.py
@@ -5,28 +5,22 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-# import json
-# from tempfile import NamedTemporaryFile
-
-
-ROOT_DIR = Path(__file__).parent.parent.parent
+import json
+from tempfile import NamedTemporaryFile
 
 
 class GoogleCalendarAPI:
     def __init__(self, scopes=["https://www.googleapis.com/auth/calendar"]):
         self.calendar_id = os.environ["CALENDAR_ID"]
-        # self.service_account_key = json.loads(os.environ["GCP_SERVICE_ACCOUNT_KEY"])
-        self.service_account_key_path = ROOT_DIR.joinpath("credentials.json")
+        self.service_account_key = json.loads(os.environ["GCP_SERVICE_ACCOUNT_KEY"])
         self.scopes = scopes
 
     def authenticate(self):
-        # with NamedTemporaryFile(mode="w") as service_account_file:
-        #     json.dump(self.service_account_key, service_account_file)
-        #     service_account_file.flush()
-        #     creds = service_account.Credentials.from_service_account_file(service_account_file.name)
-        creds = service_account.Credentials.from_service_account_file(
-            self.service_account_key_path
-        )
+        with NamedTemporaryFile(mode="w") as service_account_file:
+            json.dump(self.service_account_key, service_account_file)
+            service_account_file.flush()
+            creds = service_account.Credentials.from_service_account_file(service_account_file.name)
+
         creds = creds.with_scopes(self.scopes)
 
         try:

--- a/src/calendar/gcal_api_auth.py
+++ b/src/calendar/gcal_api_auth.py
@@ -1,12 +1,10 @@
+import json
 import os
-from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-
-import json
-from tempfile import NamedTemporaryFile
 
 
 class GoogleCalendarAPI:
@@ -19,7 +17,9 @@ class GoogleCalendarAPI:
         with NamedTemporaryFile(mode="w") as service_account_file:
             json.dump(self.service_account_key, service_account_file)
             service_account_file.flush()
-            creds = service_account.Credentials.from_service_account_file(service_account_file.name)
+            creds = service_account.Credentials.from_service_account_file(
+                service_account_file.name
+            )
 
         creds = creds.with_scopes(self.scopes)
 

--- a/src/calendar/gcal_api_auth.py
+++ b/src/calendar/gcal_api_auth.py
@@ -1,0 +1,35 @@
+import os
+from pathlib import Path
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+# import json
+# from tempfile import NamedTemporaryFile
+
+
+ROOT_DIR = Path(__file__).parent.parent.parent
+
+
+class GoogleCalendarAPI:
+    def __init__(self, scopes=["https://www.googleapis.com/auth/calendar"]):
+        self.calendar_id = os.environ["CALENDAR_ID"]
+        # self.service_account_key = json.loads(os.environ["GCP_SERVICE_ACCOUNT_KEY"])
+        self.service_account_key_path = ROOT_DIR.joinpath("credentials.json")
+        self.scopes = scopes
+
+    def authenticate(self):
+        # with NamedTemporaryFile(mode="w") as service_account_file:
+        #     json.dump(self.service_account_key, service_account_file)
+        #     service_account_file.flush()
+        #     creds = service_account.Credentials.from_service_account_file(service_account_file.name)
+        creds = service_account.Credentials.from_service_account_file(
+            self.service_account_key_path
+        )
+        creds = creds.with_scopes(self.scopes)
+
+        try:
+            return build("calendar", "v3", credentials=creds)
+        except HttpError as error:
+            print("An error occurred: %s" % error)

--- a/src/calendar/gcal_api_auth.py
+++ b/src/calendar/gcal_api_auth.py
@@ -1,5 +1,9 @@
+"""
+Authenticate with Google's Calendar API using a Service Account
+"""
 import json
 import os
+import sys
 from tempfile import NamedTemporaryFile
 
 from google.oauth2 import service_account
@@ -8,12 +12,15 @@ from googleapiclient.errors import HttpError
 
 
 class GoogleCalendarAPI:
+    """Interact with the Google Calendar API"""
+
     def __init__(self, scopes=["https://www.googleapis.com/auth/calendar"]):
         self.calendar_id = os.environ["CALENDAR_ID"]
         self.service_account_key = json.loads(os.environ["GCP_SERVICE_ACCOUNT_KEY"])
         self.scopes = scopes
 
     def authenticate(self):
+        """Return an authenticated instance of Google's Calendar API"""
         with NamedTemporaryFile(mode="w") as service_account_file:
             json.dump(self.service_account_key, service_account_file)
             service_account_file.flush()
@@ -26,4 +33,5 @@ class GoogleCalendarAPI:
         try:
             return build("calendar", "v3", credentials=creds)
         except HttpError as error:
-            print("An error occurred: %s" % error)
+            print(f"An error occurred: {error}")
+            sys.exit(1)


### PR DESCRIPTION
Add scripts that use the Google Calendar API to create events for the Team Roles in a calendar. Events can be created either:

- in bulk, add a large number of events in one go
- on a rolling update basis, the next event is generated based on the last event pulled from the calendar