### PR TITLE
Update to use multiple usergroups

### DIFF
--- a/.github/workflows/meeting-facilitator.yaml
+++ b/.github/workflows/meeting-facilitator.yaml
@@ -14,14 +14,14 @@ on:
           and the members currently listed there will be used in the standup.
       team-name:
         required: false
-        default: tech-team
+        default: meeting-facilitators
         description: |
           The Slack team our Team Roles are generated from
   schedule:
     - cron: "0 0 28 * *"  # Run at 00:00 UTC on the 28th of each month
 
 env:
-  TEAM_NAME: tech-team
+  TEAM_NAME: meeting-facilitators
 
 jobs:
   create-standup:

--- a/.github/workflows/populate-current-roles.yaml
+++ b/.github/workflows/populate-current-roles.yaml
@@ -20,9 +20,10 @@ on:
           the Support Steward role (i.e. for less than two weeks)
       team-name:
         required: false
-        default: tech-team
+        default: meeting-facilitators,support-stewards
         description: |
-          The Slack team our Team Roles are generated from
+          The Slack team(s) our Team Roles are generated from. If providing multiple
+          teams, separate them with a comma ",".
       standup-manager:
         required: false
         default: "Sarah"

--- a/.github/workflows/support-steward.yaml
+++ b/.github/workflows/support-steward.yaml
@@ -14,14 +14,14 @@ on:
           and the members currently listed there will be used in the standup.
       team-name:
         required: false
-        default: tech-team
+        default: support-stewards
         description: |
           The Slack team our Team Roles are generated from
   schedule:
     - cron: "0 0 * * MON"  # Run at 00:00 UTC weekly on Mondays
 
 env:
-  TEAM_NAME: "tech-team"
+  TEAM_NAME: support-stewards
 
 jobs:
   is-two-weeks:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Team Roles Geekbot Sweep
 
-A Slack/Geekbot/Google Calendar App to sweep through our Tech Team, assign Team Roles, and track them in our Team Roles calendar
+A Slack/Geekbot/Google Calendar App to sweep through 2i2c team members, assign Team Roles, and track them in our Team Roles calendar
 
 ## Summary
 
-This repository is a collection of Python code that tracks which members of 2i2c's Tech Team (as defined by membership of the `tech-team` Slack team) are currently serving in our Team Roles (Meeting Facilitator and Support Steward), works out which team member is due to take over the role, and dynamically generate Geekbot standups in Slack to visibly and explicitly notify the given team member that they are due to take over the role.
+This repository is a collection of Python code that tracks which 2i2c team members are currently serving in our Team Roles (Meeting Facilitator and Support Steward).
+The code works out which team member is due to take over a given role, and dynamically generates Geekbot standups in Slack to visibly and explicitly notify the given team member that they are due to take over the role.
 It also creates events in the Team Roles Google Calendar to make the role changes more visible.
 
 ### Useful Documentation
@@ -32,10 +33,10 @@ poetry install
 
 ## Team Roles JSON file structure
 
-Which members of the Tech Team are serving (or have served) in a given role are stored in the `team-roles.json` file, which has the below structure.
+Which 2i2c teams members are serving (or have served) in a given role are stored in the `team-roles.json` file, which has the below structure.
 
 We keep track of both a team members Slack display name and user ID.
-This is because interacting with the APIs requires the user ID, but it is more human-readable to also have the names.
+This is because interacting with the Slack and Geekbot APIs requires the user ID, but it is more human-readable to also have the names.
 
 For the Support Steward, we track both the current and incoming team members as we have two people overlapping in this role.
 
@@ -76,7 +77,7 @@ All scripts are written in Python and are located in the [`src`](src/) folder.
 This script interacts with the Slack API to produce a dictionary of Slack users who are members of a given Slack team (formally called a "usergroup" in the API), and their IDs.
 The script requires two environment variables to be set:
 
-- `TEAM_NAME`: The name of the Slack team to list members of, e.g., `tech-team`
+- `TEAM_NAME`: The name of the Slack team to list members of, e.g., `meeting-facilitators` or `support-stewards`
 - `SLACK_BOT_TOKEN`: A bot user token for a Slack App installed into the workspace.
   The bot requires the `usergroups:read` and `users:read` permission scopes to operate.
   It does not need to be a member of any channels in the Slack workspace.
@@ -94,9 +95,9 @@ poetry run list-team-members
 
 ### `update_team_roles.py`
 
-This script generates the next team member to serve in a given role by iterating one place through the Tech Team.
-It depends on [`get_slack_team_members.py`](#get_slack_team_memberspy) to pull the list of tech team members from Slack.
-The team member currently serving in the role is pulled from the current event in the Team Roles calendar.
+This script generates the next team member to serve in a given role by iterating one place through the appropriate Slack team (either `meeting-facilitators` or `support-stewards`).
+It depends on [`get_slack_team_members.py`](#get_slack_team_memberspy) to pull the list of team members from Slack.
+The team member _currently_ serving in the role is pulled from the current event in the Team Roles calendar.
 If no event is found, the current team member is read from the `team-roles.json` file.
 The updated team roles are written back to the same file.
 There are command line options to determine which role is to be updated.
@@ -114,7 +115,7 @@ poetry run update-team-role { meeting-facilitator | support-steward }
 ```bash
 usage: update-team-role [-h] {meeting-facilitator,support-steward}
 
-Update our Team Roles by iterating through members of the Tech Team
+Update our Team Roles by iterating through 2i2c team members
 
 positional arguments:
   {meeting-facilitator,support-steward}
@@ -147,7 +148,7 @@ poetry run create-standup { meeting-facilitator | support-steward }
 ```bash
 usage: create-standup [-h] {meeting-facilitator,support-steward}
 
-Create Geekbot standup apps to manage the transition of Team Roles through the Tech Team
+Create Geekbot standup apps to manage the transition of Team Roles through 2i2c team members
 
 positional arguments:
   {meeting-facilitator,support-steward}
@@ -247,7 +248,7 @@ poetry run create-bulk-events { meeting-facilitator | support-steward }
 **Help info:**
 
 ```bash
-usage: create-bulk-events [-h] [-n N_EVENTS] [-d DATE] {meeting-facilitator,support-steward}
+usage: create-bulk-events [-h] [-m TEAM_MEMBER] [-n N_EVENTS] [-d DATE] {meeting-facilitator,support-steward}
 
 Bulk create a series of Team Role events in a Google Calendar
 
@@ -257,11 +258,11 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  -m TEAM_MEMBER, --team-member TEAM_MEMBER
+                        The name of the team member currently serving in the role. Will be pulled from team-roles.json if not provided.
   -n N_EVENTS, --n-events N_EVENTS
-                        The number of role events to create. Defaults to 12 for Meeting
-                        Facilitator and 26 for Support Steward (both 1 year's worth).
-  -d DATE, --date DATE  A reference date to begin creating events from. Defaults to today.
-                        WARNING: EXPERIMENTAL FEATURE.
+                        The number of role events to create. Defaults to 12 for Meeting Facilitator and 26 for Support Steward (both 1 year's worth).
+  -d DATE, --date DATE  A reference date to begin creating events from. Defaults to today. WARNING: EXPERIMENTAL FEATURE.
 ```
 
 ### `gcal_api_auth.py`

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ This script is used to create the next event for a Team Role given that a series
 It calculates the required metadata for the new event from the last event available on the calendar.
 It depends upon [`get_slack_team_members.py`](#get_slack_team_memberspy) to get an ordered list of the team members who fulfil these roles.
 
-In addition to the two environment variables required be `get_slack_team_members.py`, this script also requires the following environment variables to be set:
+In addition to the two environment variables required be `get_slack_team_members.py` (Note: `team_name` has been promoted to an environment variable for this script), this script also requires the following environment variables to be set:
 
 - `GCP_SERVICE_ACCOUNT_KEY`: A Google Cloud Service Account with permissions to access Google's Calendar API
 - `CALENDAR_ID`: The ID of a Google Calendar to which the above Service Account has permission to manage events
@@ -236,7 +236,7 @@ This script is used to generate a large number of events for a Team Role in a Go
 It begins generating events either from the day the script is executed or from a provided reference date.
 It depends upon [`get_slack_team_members.py`](#get_slack_team_memberspy) to get an ordered list of the team members who fulfil these roles.
 
-In addition to the two environment variables required be `get_slack_team_members.py`, this script also requires the following environment variables to be set:
+In addition to the two environment variables required be `get_slack_team_members.py` (Note: `team_name` has been promoted to an environment variable for this script), this script also requires the following environment variables to be set:
 
 - `GCP_SERVICE_ACCOUNT_KEY`: A Google Cloud Service Account with permissions to access Google's Calendar API
 - `CALENDAR_ID`: The ID of a Google Calendar to which the above Service Account has permission to manage events

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ All scripts are written in Python and are located in the [`src`](src/) folder.
 ### `get_slack_team_members.py`
 
 This script interacts with the Slack API to produce a dictionary of Slack users who are members of a given Slack team (formally called a "usergroup" in the API), and their IDs.
-The script requires two environment variables to be set:
+The script requires two variables to be set:
 
-- `TEAM_NAME`: The name of the Slack team to list members of, e.g., `meeting-facilitators` or `support-stewards`
-- `SLACK_BOT_TOKEN`: A bot user token for a Slack App installed into the workspace.
+- `team_name` (cli argument): The name of the Slack team to list members of, e.g., `meeting-facilitators` or `support-stewards`
+- `SLACK_BOT_TOKEN` (environment variable): A bot user token for a Slack App installed into the workspace.
   The bot requires the `usergroups:read` and `users:read` permission scopes to operate.
   It does not need to be a member of any channels in the Slack workspace.
 
@@ -91,6 +91,20 @@ Running the following command will print the dictionary of team members' names a
 
 ```bash
 poetry run list-team-members
+```
+
+**Help info:**
+
+```bash
+usage: list-team-members [-h] team_name
+
+List the members and IDs of a Slack usergroup
+
+positional arguments:
+  team_name   The name of the Slack usergroup to list members of
+
+optional arguments:
+  -h, --help  show this help message and exit
 ```
 
 ### `update_team_roles.py`

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ optional arguments:
 ### `update_team_roles.py`
 
 This script generates the next team member to serve in a given role by iterating one place through the appropriate Slack team (either `meeting-facilitators` or `support-stewards`).
-It depends on [`get_slack_team_members.py`](#get_slack_team_memberspy) to pull the list of team members from Slack.
+It depends on [`get_slack_team_members.py`](#get_slack_team_memberspy) to pull the list of team members from Slack and therefore needs those environment variables set (Note: `team_name` is promoted to an environment variable for this script).
 The team member _currently_ serving in the role is pulled from the current event in the Team Roles calendar.
 If no event is found, the current team member is read from the `team-roles.json` file.
 The updated team roles are written back to the same file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "src"
 version = "0.1.0"
-description = "A tool to automatically assign 2i2c Tech Team members to various Team Roles"
+description = "A tool to automatically assign 2i2c team members to various Team Roles"
 license = "MIT"
 authors = []
 

--- a/src/calendar/create_events_bulk.py
+++ b/src/calendar/create_events_bulk.py
@@ -37,8 +37,12 @@ class CreateBulkEvents:
 
     def __init__(self, date=None):
         self.calendar_id = os.environ["CALENDAR_ID"]
+        team_name = os.environ["TEAM_NAME"]
+
         self._generate_reference_date(date=date)
-        self.team_members = SlackTeamMembers().get_users_in_team().keys()
+
+        self.team_members = SlackTeamMembers().get_users_in_team(team_name=team_name).keys()
+
         self.gcal_api = GoogleCalendarAPI().authenticate()
 
         project_path = Path(__file__).parent.parent.parent

--- a/src/calendar/create_events_bulk.py
+++ b/src/calendar/create_events_bulk.py
@@ -41,7 +41,9 @@ class CreateBulkEvents:
 
         self._generate_reference_date(date=date)
 
-        self.team_members = SlackTeamMembers().get_users_in_team(team_name=team_name).keys()
+        self.team_members = (
+            SlackTeamMembers().get_users_in_team(team_name=team_name).keys()
+        )
 
         self.gcal_api = GoogleCalendarAPI().authenticate()
 

--- a/src/calendar/create_events_rolling_update.py
+++ b/src/calendar/create_events_rolling_update.py
@@ -39,7 +39,9 @@ class CreateNextEvent:
         team_name = os.environ["TEAM_NAME"]
 
         self.gcal_api = GoogleCalendarAPI().authenticate()
-        self.team_members = SlackTeamMembers().get_users_in_team(team_name=team_name).keys()
+        self.team_members = (
+            SlackTeamMembers().get_users_in_team(team_name=team_name).keys()
+        )
 
         self._get_todays_date()
 

--- a/src/calendar/create_events_rolling_update.py
+++ b/src/calendar/create_events_rolling_update.py
@@ -36,8 +36,10 @@ class CreateNextEvent:
 
     def __init__(self):
         self.calendar_id = os.environ["CALENDAR_ID"]
+        team_name = os.environ["TEAM_NAME"]
+
         self.gcal_api = GoogleCalendarAPI().authenticate()
-        self.team_members = SlackTeamMembers().get_users_in_team().keys()
+        self.team_members = SlackTeamMembers().get_users_in_team(team_name=team_name).keys()
 
         self._get_todays_date()
 

--- a/src/geekbot/create_geekbot_standup.py
+++ b/src/geekbot/create_geekbot_standup.py
@@ -1,6 +1,6 @@
 """
 Functions to create Geekbot Standups in Slack to aid the transition of our Team Roles
-through the Tech Team
+through 2i2c team members
 """
 import argparse
 import json
@@ -126,7 +126,7 @@ class GeekbotStandup:
             + "https://calendar.google.com/calendar/embed?src=c_4hjjouojd8psql9i1a8nd1uff4%40group.calendar.google.com"
             + "\n\n"
             + "Reply 'ok' to this message to acknowledge your role. "
-            + "Or if you are not able to fulfil this role at this time, please arrange cover with another member of the Tech Team. "
+            + "Or if you are not able to fulfil this role at this time, please arrange cover with another member of the team. "
             + "If you have already swapped with someone, please tag them in your response."
             + "\n\n"
             + "Here are some actions the meeting facilitator is expected to take:\n"
@@ -153,7 +153,7 @@ class GeekbotStandup:
             + "https://2i2c.freshdesk.com/a/tickets/filters/all_tickets"
             + "\n\n"
             + "Reply 'ok' to this message to acknowledge your role. "
-            + "Or if you are going to be away for a large part of your stewardship, please arrange cover with another member of the Tech Team. "
+            + "Or if you are going to be away for a large part of your stewardship, please arrange cover with another member of the team. "
             + "If you have already swapped with someone, please tag them in your response."
             + "\n\n"
             + f"Your support steward buddy is: {self.steward_buddy.split()[0]}"
@@ -254,7 +254,7 @@ def main():
     # Create a command line parser
     parser = argparse.ArgumentParser(
         description="""
-            Create Geekbot standup apps to manage the transition of Team Roles through the Tech Team
+            Create Geekbot standup apps to manage the transition of Team Roles through 2i2c team members
         """
     )
     parser.add_argument(

--- a/src/geekbot/get_slack_team_members.py
+++ b/src/geekbot/get_slack_team_members.py
@@ -93,10 +93,23 @@ class SlackTeamMembers:
 
 
 def main():
+    import argparse
     from rich import print_json
 
+    parser = argparse.ArgumentParser(
+        description="List the members and IDs of a Slack usergroup"
+    )
+
+    parser.add_argument(
+        "team_name",
+        type=str,
+        help="The name of the Slack usergroup to list members of",
+    )
+
+    args = parser.parse_args()
+
     app = SlackTeamMembers()
-    usernames = app.get_users_in_team()
+    usernames = app.get_users_in_team(team_name=args.team_name)
     print_json(data=usernames)
 
 

--- a/src/geekbot/get_slack_team_members.py
+++ b/src/geekbot/get_slack_team_members.py
@@ -94,6 +94,7 @@ class SlackTeamMembers:
 
 def main():
     import argparse
+
     from rich import print_json
 
     parser = argparse.ArgumentParser(

--- a/src/geekbot/get_slack_team_members.py
+++ b/src/geekbot/get_slack_team_members.py
@@ -14,38 +14,35 @@ class SlackTeamMembers:
     """
 
     def __init__(self):
-        # Set variables
-        self.team_name = os.environ["TEAM_NAME"]
-
         # Instantiate a SLACK API client
         self.client = WebClient(token=os.environ["SLACK_BOT_TOKEN"])
 
-    def _get_team_id(self):
+    def _get_team_id(self, team_name):
         """
         Retrieve the ID of a given Slack team
         """
-        logger.info(f"Retrieving ID for Slack team: {self.team_name}")
+        logger.info(f"Retrieving ID for Slack team: {team_name}")
 
         # Get all usergroups in workspace
         response = self.client.api_call(api_method="usergroups.list")
 
-        # Find ID for the self.team_name usergroup
+        # Find ID for the team_name usergroup
         index = next(
             idx
             for (idx, usergroup) in enumerate(response["usergroups"])
-            if usergroup["handle"] == self.team_name
+            if usergroup["handle"] == team_name
         )
         self.usergroup_id = response["usergroups"][index]["id"]
 
-    def _get_user_ids(self):
+    def _get_user_ids(self, team_name):
         """
         Retrieve the user IDs of the members of a given usergroup
         """
-        self._get_team_id()
+        self._get_team_id(team_name=team_name)
 
-        logger.info(f"Retrieving user IDs for members of Slack team: {self.team_name}")
+        logger.info(f"Retrieving user IDs for members of Slack team: {team_name}")
 
-        # Find all user IDs in the self.team_name usergroup
+        # Find all user IDs in the team_name usergroup
         response = self.client.api_call(
             api_method="usergroups.users.list",
             params={"usergroup": self.usergroup_id},
@@ -73,7 +70,7 @@ class SlackTeamMembers:
 
         return username
 
-    def get_users_in_team(self):
+    def get_users_in_team(self, team_name):
         """Retrieve the members of a Slack usergroup
 
         Returns:
@@ -81,7 +78,7 @@ class SlackTeamMembers:
                 'real names', or display names if available, and values are the users'
                 IDs.
         """
-        self._get_user_ids()
+        self._get_user_ids(team_name=team_name)
 
         logger.info("Converting user IDs into display names")
         user_handles_and_ids = {}

--- a/src/geekbot/update_team_roles.py
+++ b/src/geekbot/update_team_roles.py
@@ -14,7 +14,7 @@ from .get_slack_team_members import SlackTeamMembers
 
 
 class TeamRoles:
-    """Iterate our Team Roles through the Tech Team"""
+    """Iterate our Team Roles through 2i2c team members"""
 
     def __init__(self):
         self.calendar_id = os.environ["CALENDAR_ID"]
@@ -211,7 +211,7 @@ class TeamRoles:
 
     def update_roles(self, role):
         """Update our Team Roles by inspecting a Google Calendar and/or iterating
-        through members of the Tech Team
+        through 2i2c team members
 
         Args:
             role (str): The role to update. Either 'meeting-facilitator' or
@@ -240,7 +240,7 @@ class TeamRoles:
 def main():
     # Construct a command line parser
     parser = argparse.ArgumentParser(
-        description="Update our Team Roles by iterating through members of the Tech Team"
+        description="Update our Team Roles by iterating through 2i2c team members"
     )
     parser.add_argument(
         "role",

--- a/src/geekbot/update_team_roles.py
+++ b/src/geekbot/update_team_roles.py
@@ -18,9 +18,10 @@ class TeamRoles:
 
     def __init__(self):
         self.calendar_id = os.environ["CALENDAR_ID"]
+        team_name = os.environ["TEAM_NAME"]
 
         # Populate team members
-        self.team_members = SlackTeamMembers().get_users_in_team()
+        self.team_members = SlackTeamMembers().get_users_in_team(team_name=team_name)
 
         # Instatiate the GoogleCalendarAPI class
         self.gcal_api = GoogleCalendarAPI().authenticate()


### PR DESCRIPTION
In https://github.com/2i2c-org/team-compass/issues/475, I proposed using specific Slack usergroups to decouple the meeting facilitator and support steward role both from each other, and from member of the `tech-team` usergroup.

This PR updates the code to handle pulling roles from different/multiple usergroup. It involved explicitly setting the usergroup name in `get_slack_team_members.py` and so other code needed to be updated to pass the usergroup name as an argument, rather than relying on environment variables.