### PR TITLE
Set correct meeting facilitator

### DIFF
--- a/src/calendar/create_events_bulk.py
+++ b/src/calendar/create_events_bulk.py
@@ -219,7 +219,7 @@ class CreateBulkEvents:
             (
                 i
                 for (i, name) in enumerate(self.usergroup_members)
-                if current_member in name
+                if current_member.lowercase() in name.lowercase()
             ),
             None,
         )

--- a/src/calendar/create_events_rolling_update.py
+++ b/src/calendar/create_events_rolling_update.py
@@ -122,7 +122,7 @@ class CreateNextEvent:
             (
                 i
                 for (i, name) in enumerate(self.usergroup_members)
-                if last_member in name
+                if last_member.lowercase() in name.lowercase()
             ),
             None,
         )

--- a/src/geekbot/update_team_roles.py
+++ b/src/geekbot/update_team_roles.py
@@ -68,7 +68,7 @@ class TeamRoles:
             (
                 i
                 for (i, name) in enumerate(self.usergroup_members.keys())
-                if current_member in name
+                if current_member.lowercase() in name.lowercase()
             ),
             None,
         )
@@ -180,7 +180,7 @@ class TeamRoles:
             (
                 id
                 for (name, id) in self.usergroup_members.items()
-                if next_member_name in name
+                if next_member_name.lowercase() in name.lowercase()
             ),
             None,
         )
@@ -204,7 +204,7 @@ class TeamRoles:
             (
                 id
                 for (name, id) in self.usergroup_members.items()
-                if next_member_name in name
+                if next_member_name.lowercase() in name.lowercase()
             ),
             None,
         )

--- a/team-roles.json
+++ b/team-roles.json
@@ -14,7 +14,7 @@
         },
         "current": {
             "name": "Yuvi",
-            "id": null
+            "id": "UKNHAAGHF"
         }
     }
 }

--- a/team-roles.json
+++ b/team-roles.json
@@ -4,8 +4,8 @@
         "id": "U01G3RJP1U3"
     },
     "meeting_facilitator": {
-        "name": "Erik",
-        "id": "U01742BQ99N"
+        "name": "Damian",
+        "id": "U01GKCV6PBL"
     },
     "support_steward": {
         "incoming": {


### PR DESCRIPTION
We got a little bit out of sync with the Team Roles calendar and Geekbot - I expect because I merged a PR that made the code aware of the calendar after a Standup had been created. This PR sets the current meeting facilitator to match the Team Roles calendar (as of today 23rd Aug 2022). It also adds in Yuvi's Slack user ID which was null for some reason. This should be fixed by the commit that ensures names are in lowercase for comparison.