### PR TITLE
Use sops to handle secrets locally

### DIFF
--- a/.github/workflows/meeting-facilitator.yaml
+++ b/.github/workflows/meeting-facilitator.yaml
@@ -49,15 +49,23 @@ jobs:
           pip install poetry
           poetry install
 
+      # This action use the github official cache mechanism internally
+      - name: Install sops
+        uses: mdgreenwald/mozilla-sops-action@v1
+        with:
+          version: v3.7.2
+
+      - name: Setup sops credentials to decrypt repo secrets
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: "${{ secrets.GCP_KMS_DECRYPTOR_KEY }}"
+
       - name: Update team member in role
         if: github.event_name == 'schedule' || github.event.inputs.update-roles == 'true'
         run: |
           poetry run update-team-role meeting-facilitator
         env:
           USERGROUP_NAME: "${{ github.event.inputs.usergroup-name || env.USERGROUP_NAME }}"
-          SLACK_BOT_TOKEN: "${{ secrets.SLACK_BOT_TOKEN }}"
-          CALENDAR_ID: "${{ secrets.CALENDAR_ID }}"
-          GCP_SERVICE_ACCOUNT_KEY: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
 
       - name: Add and Commit updated team-roles.json file
         if: github.event_name == 'schedule' || github.event.inputs.update-roles == 'true'
@@ -70,8 +78,6 @@ jobs:
       - name: Create a standup for the Meeting Facilitator
         run: |
           poetry run create-standup meeting-facilitator
-        env:
-          GEEKBOT_API_KEY: "${{ secrets.GEEKBOT_API_KEY }}"
 
   update-calendar:
     runs-on: ubuntu-latest
@@ -93,11 +99,19 @@ jobs:
           pip install poetry
           poetry install
 
+      # This action use the github official cache mechanism internally
+      - name: Install sops
+        uses: mdgreenwald/mozilla-sops-action@v1
+        with:
+          version: v3.7.2
+
+      - name: Setup sops credentials to decrypt repo secrets
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: "${{ secrets.GCP_KMS_DECRYPTOR_KEY }}"
+
       - name: Create next Meeting Facilitator event in the calendar
         run: |
           poetry run create-next-event meeting-facilitator
         env:
           USERGROUP_NAME: "${{ github.event.inputs.usergroup-name || env.USERGROUP_NAME }}"
-          SLACK_BOT_TOKEN: "${{ secrets.SLACK_BOT_TOKEN }}"
-          CALENDAR_ID: "${{ secrets.CALENDAR_ID }}"
-          GCP_SERVICE_ACCOUNT_KEY: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"

--- a/.github/workflows/meeting-facilitator.yaml
+++ b/.github/workflows/meeting-facilitator.yaml
@@ -33,7 +33,6 @@ env:
 jobs:
   create-standup:
     runs-on: ubuntu-latest
-    environment: run-slack-bot
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -83,7 +82,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.inputs.update-calendar == 'true' || github.event_name == 'schedule'
     needs: create-standup
-    environment: run-slack-bot
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/populate-current-roles.yaml
+++ b/.github/workflows/populate-current-roles.yaml
@@ -36,7 +36,6 @@ on:
 jobs:
   populate-team-roles:
     runs-on: ubuntu-latest
-    environment: run-slack-bot
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/populate-current-roles.yaml
+++ b/.github/workflows/populate-current-roles.yaml
@@ -52,6 +52,17 @@ jobs:
           pip install poetry
           poetry install
 
+      # This action use the github official cache mechanism internally
+      - name: Install sops
+        uses: mdgreenwald/mozilla-sops-action@v1
+        with:
+          version: v3.7.2
+
+      - name: Setup sops credentials to decrypt repo secrets
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: "${{ secrets.GCP_KMS_DECRYPTOR_KEY }}"
+
       - name: Populate team-roles.json
         run: |
           poetry run populate-current-roles
@@ -61,7 +72,6 @@ jobs:
           INCOMING_SUPPORT_STEWARD: "${{ github.event.inputs.incoming-support-steward }}"
           USERGROUP_NAMES: "${{ github.event.inputs.usergroup-name }}"
           STANDUP_MANAGER: "${{ github.event.inputs.standup-manager }}"
-          SLACK_BOT_TOKEN: "${{ secrets.SLACK_BOT_TOKEN }}"
 
       - name: Add and Commit updated team-roles.json file
         uses: EndBug/add-and-commit@v9

--- a/.github/workflows/support-steward.yaml
+++ b/.github/workflows/support-steward.yaml
@@ -61,7 +61,6 @@ jobs:
 
   create-standup:
     runs-on: ubuntu-latest
-    environment: run-slack-bot
     needs:
       - is-two-weeks
       - create-standup
@@ -112,7 +111,6 @@ jobs:
 
   update-calendar:
     runs-on: ubuntu-latest
-    environment: run-slack-bot
     needs: [is-two-weeks]
     if: |
       github.event.inputs.update-calendar == 'true'

--- a/.github/workflows/support-steward.yaml
+++ b/.github/workflows/support-steward.yaml
@@ -81,15 +81,23 @@ jobs:
           pip install poetry
           poetry install
 
+      # This action use the github official cache mechanism internally
+      - name: Install sops
+        uses: mdgreenwald/mozilla-sops-action@v1
+        with:
+          version: v3.7.2
+
+      - name: Setup sops credentials to decrypt repo secrets
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: "${{ secrets.GCP_KMS_DECRYPTOR_KEY }}"
+
       - name: Update team member in role
         if: github.event_name == 'schedule' || github.event.inputs.update-roles == 'true'
         run: |
           poetry run update-team-role support-steward
         env:
           USERGROUP_NAME: "${{ github.event.inputs.usergroup-name || env.USERGROUP_NAME }}"
-          SLACK_BOT_TOKEN: "${{ secrets.SLACK_BOT_TOKEN }}"
-          CALENDAR_ID: "${{ secrets.CALENDAR_ID }}"
-          GCP_SERVICE_ACCOUNT_KEY: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"
 
       - name: Add and Commit updated team-roles.json file
         if: github.event_name == 'schedule' || github.event.inputs.update-roles == 'true'
@@ -101,8 +109,6 @@ jobs:
       - name: Create a standup for the Support Steward
         run: |
           poetry run create-standup support-steward
-        env:
-          GEEKBOT_API_KEY: "${{ secrets.GEEKBOT_API_KEY }}"
 
   update-calendar:
     runs-on: ubuntu-latest
@@ -127,11 +133,19 @@ jobs:
           pip install poetry
           poetry install
 
+      # This action use the github official cache mechanism internally
+      - name: Install sops
+        uses: mdgreenwald/mozilla-sops-action@v1
+        with:
+          version: v3.7.2
+
+      - name: Setup sops credentials to decrypt repo secrets
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: "${{ secrets.GCP_KMS_DECRYPTOR_KEY }}"
+
       - name: Create next Support Steward event in the calendar
         run: |
           poetry run create-next-event support-steward
         env:
           USERGROUP_NAME: "${{ github.event.inputs.usergroup-name || env.USERGROUP_NAME }}"
-          SLACK_BOT_TOKEN: "${{ secrets.SLACK_BOT_TOKEN }}"
-          CALENDAR_ID: "${{ secrets.CALENDAR_ID }}"
-          GCP_SERVICE_ACCOUNT_KEY: "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,9 @@ repos:
         args:
           - "--max-line-length=88"
           - "--extend-ignore=E501,F841"
+
+  # Prevent unencrypted files from being committed
+  - repo: https://github.com/yuvipanda/pre-commit-hook-ensure-sops
+    rev: v1.0
+    hooks:
+      - id: sops-encryption

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,3 @@
+creation_rules:
+  - path_regex: secrets/*
+    gcp_kms: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ It also creates events in the Team Roles Google Calendar to make the role change
 - [Building a simple bot using Python in 10 minutes](https://github.com/slackapi/python-slack-sdk/tree/main/tutorial)
 - [Quickstart Guide to the Google Calendar API with Python](https://developers.google.com/calendar/api/quickstart/python)
 
-## Installation
+## Getting setup
+
+### Package Installation
 
 Installing the dependencies requires [`poetry`](https://python-poetry.org/).
 You can install the dependencies by running:
@@ -30,6 +32,12 @@ You can install the dependencies by running:
 ```bash
 poetry install
 ```
+
+### Setting up `sops` for secret decryption
+
+Secrets required to execute the code in this repository are stored in the `secrets` folder and are encrypted with [`sops`](https://github.com/mozilla/sops).
+You will therefore need to have `sops` installed to run this code locally.
+See [this guide](https://infrastructure.2i2c.org/en/latest/tutorials/setup.html#step-3-authenticate-with-google-cloud-to-decrypt-our-secret-files) to setup `sops` before executing any code here.
 
 ## Team Roles JSON file structure
 
@@ -75,12 +83,7 @@ All scripts are written in Python and are located in the [`src`](src/) folder.
 ### `get_slack_usergroup_members.py`
 
 This script interacts with the Slack API to produce a dictionary of Slack users who are members of a given Slack usergroup and their IDs.
-The script requires two variables to be set:
-
-- `usergroup_name` (cli argument): The name of the Slack usergroup to list members of, e.g., `meeting-facilitators` or `support-stewards`
-- `SLACK_BOT_TOKEN` (environment variable): A bot user token for a Slack App installed into the workspace.
-  The bot requires the `usergroups:read` and `users:read` permission scopes to operate.
-  It does not need to be a member of any channels in the Slack workspace.
+The script requires the `usergroup_name` variable to be set, which is the name of the Slack usergroup to list members of, e.g., `meeting-facilitators` or `support-stewards`.
 
 The script will generate a dictionary of members of `usergroup_name` where the keys are the users' display names, and the values are their associated user IDs.
 The dictionary is ordered alphabetically by its keys.
@@ -110,7 +113,9 @@ optional arguments:
 ### `update_team_roles.py`
 
 This script generates the next team member to serve in a given role by iterating one place through the appropriate Slack usergroup (either `meeting-facilitators` or `support-stewards`).
-It depends on [`get_slack_usergroup_members.py`](#get_slack_usergroup_memberspy) to pull the list of usergroup members from Slack and therefore needs those environment variables set (Note: `usergroup_name` is promoted to an environment variable for this script).
+It depends on [`get_slack_usergroup_members.py`](#get_slack_usergroup_memberspy) to pull the list of usergroup members from Slack.
+The desired usergroup to pull the members of is parsed to the script via the `USERGROUP_NAME` environment variable.
+
 The team member _currently_ serving in the role is pulled from the current event in the Team Roles calendar.
 If no event is found, the current team member is read from the `team-roles.json` file.
 The updated team roles are written back to the same file.
@@ -145,8 +150,6 @@ This script reads in [`team-roles.json`](#team-roles-json-file-structure) after 
 
 The `MeetingFacilitatorStandup` broadcasts to the `team-updates` Slack channel, and the `SupportStewardStandup` broadcasts to the `support-freshdesk` channel.
 The [Geekbot app](https://geekbot.com/) needs to be installed to the Slack workspace and invited to the channels to which it will broadcast.
-
-The script requires the `GEEKBOT_API_KEY` environment variable to be set with a valid API key for communicating with Geekbot's API.
 Command line options are provided to select which role a standup should be created for.
 
 **Command line usage:**
@@ -181,14 +184,12 @@ This script requires the following environment variables to be set:
 
 - `USERGROUP_NAMES`: The name of the Slack usergroup to list members of, e.g., `meeting-facilitators` or `support-stewards`.
   Multiple usergroups can be provided by separating them with a comma.
-- `SLACK_BOT_TOKEN`: A bot user token for a Slack App installed into the workspace.
-  (See above for more details.)
 - `CURRENT_MEETING_FACILITATOR`: The Slack display name of the team member currently serving in the Meeting Facilitator role
 - `CURRENT_SUPPORT_STEWARD`: The Slack display name of the team member currently serving in the Support Steward role (i.e. for more than two weeks)
 - `INCOMING_SUPPORT_STEWARD`: The Slack display name of the team member most recently taking up service in the Support Steward role (i.e. for less than two weeks)
-- `STANDUP_MANAGER`: This is the Slack display name of the team member who created `GEEKBOT_API_KEY` and will be added to all standups.
+- `STANDUP_MANAGER`: This is the Slack display name of the team member who created `geekbot_api_token.json` and will be added to all standups.
   This role is required since Geekbot only offers personal API keys and the script won't be able to see any exisitng standups that the owner of the key is not a member of.
-  :fire: **If you are changing this role, you will need to recreate `GEEKBOT_API_KEY`.** :fire:
+  :fire: **If you are changing this role, you will need to recreate `geekbot_api_token.json`.** :fire:
 
 This script is paired with the [`populate-current-roles` workflow](#populate-current-rolesyaml) to commit the updated `team-roles.json` file to the repo for future CI/CD runs of the bot.
 
@@ -205,11 +206,7 @@ poetry run populate-current-roles
 This script is used to create the next event for a Team Role given that a series of events already exist in a Google Calendar.
 It calculates the required metadata for the new event from the last event available on the calendar.
 It depends upon [`get_slack_usergroup_members.py`](#get_slack_usergroup_memberspy) to get an ordered list of the team members who fulfil these roles.
-
-In addition to the two environment variables required be `get_slack_usergroup_members.py` (Note: `usergroup_name` has been promoted to an environment variable for this script), this script also requires the following environment variables to be set:
-
-- `GCP_SERVICE_ACCOUNT_KEY`: A Google Cloud Service Account with permissions to access Google's Calendar API
-- `CALENDAR_ID`: The ID of a Google Calendar to which the above Service Account has permission to manage events
+The desired usergroup is parsed to the script via the `USERGROUP_NAME` environment variable.
 
 **Command line usage:**
 
@@ -239,11 +236,7 @@ optional arguments:
 This script is used to generate a large number of events for a Team Role in a Google Calendar in bulk.
 It begins generating events either from the day the script is executed or from a provided reference date.
 It depends upon [`get_slack_usergroup_members.py`](#get_slack_usergroup_memberspy) to get an ordered list of the team members who fulfil these roles.
-
-In addition to the two environment variables required be `get_slack_usergroup_members.py` (Note: `usergroup_name` has been promoted to an environment variable for this script), this script also requires the following environment variables to be set:
-
-- `GCP_SERVICE_ACCOUNT_KEY`: A Google Cloud Service Account with permissions to access Google's Calendar API
-- `CALENDAR_ID`: The ID of a Google Calendar to which the above Service Account has permission to manage events
+The desired usergroup is parsed to the script via the `USERGROUP_NAME` environment variable.
 
 #### :fire: Reference Dates for the Support Steward :fire:
 
@@ -288,6 +281,10 @@ optional arguments:
 
 This script is a helper script that returns an authenticated instance of the Google Calendar API for the [`create_events_rolling_update.py`](#create_events_rolling_updatepy) and [`create_events_bulk.py`](#create_events_bulkpy) to create events in a Google Calendar.
 
+### `sops.py`
+
+This is a helper script that securely decrypts secrets using `sops` into a temporary file for use throughout the package.
+
 ## CI/CD workflows
 
 All our CI/CD workflows are powered by [GitHub Actions](https://docs.github.com/en/actions) and the configuration is located in the [`.github/workflows`](.github/workflows/) folder.
@@ -325,3 +322,14 @@ When manually triggered, updating the team roles file is optional, for example i
 
 The `update-calendar` job runs the [`create_events_rolling_update.py`](#create_events_rolling_updatepy) script to create the next event in the series, keeping the calendar populated roughly one year in advance.
 If running manually, this job can be skipped completely.
+
+## Regarding secrets
+
+The following secrets with stated permissions are stored in the `secrets` folder.
+
+- `calendar_id.json`: The ID of a Google Calendar to which a GCP Service Account has permission to manage events
+- `gcp_service_account.json`: A Google Cloud Service Account Key with permissions to access Google's Calendar API
+- `geekbot_api_token.json`: A personal API token from the `STANDUP_MANAGER`'s account to authenticate against the Geekbot API
+- `slack_bot_token.json`: A bot user token for a Slack App installed into the workspace.
+  The bot requires the `usergroups:read` and `users:read` permission scopes to operate.
+  It does not need to be a member of any channels in the Slack workspace.

--- a/README.md
+++ b/README.md
@@ -293,7 +293,6 @@ All our CI/CD workflows are powered by [GitHub Actions](https://docs.github.com/
 
 This workflow runs the [`set_current_roles.py` script](#set_current_rolespy) to generate an initial `team-roles.json` file and commit it to the repo for use in future GitHub Actions workflow runs.
 It can be triggered manually and requires the environment variables required by `set_current_roles.py` and [`get_slack_usergroup_members.py`](#get_slack_usergroup_memberspy) to be provided as inputs.
-Note that `SLACK_BOT_TOKEN` is provided via a GitHub Action Environment Secret.
 
 ### `meeting-facilitator.yaml`
 

--- a/secrets/calendar_id.json
+++ b/secrets/calendar_id.json
@@ -1,0 +1,21 @@
+{
+	"calendar_id": "ENC[AES256_GCM,data:u7h0BhDljeGjK1mFzHtIm3m1Utn6nqmYmA+H+Srb95SEV39Zgscxmp4ihT/jAPoyIzC9N+0y,iv:sN5FLrWh8RZeHi92BWwgomeSvEkGFrek6PykGbeQNhU=,tag:NXzvPohgsSG9dxQsSGIKXA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+				"created_at": "2022-09-02T10:12:41Z",
+				"enc": "CiQA4OM7eCCdPZVAA5rSW2BW2ZdA/uYKH8aqKDJFPm8n1s2nI9wSSQDuy/p8YgpFi0z9wEGeOaeW7Mrz+phesVdHvSGzz/PQQd1b7UxUkWf07Stiptn86cNtMP4kesMB7ZXntk4Z43lPoTmGBH/qYUY="
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-09-02T10:12:42Z",
+		"mac": "ENC[AES256_GCM,data:n8is5JKdliUYbX74lsiZN/cqp7uXif8pyo2PHsGmjrIL8ZezCROc9tWaTuhGv1Xek3VH06Cw/W0IejzVpJzAVRcnwrerpn9TxlvFR9sYjpyQS0EWQfOMn6uAX3RTHZE8C/T6e3aDDOqZxJtLdKySMwtMOfa3DW85RUmgjyLGRN8=,iv:x+kxYMMwFFbMxse2mU02pogEUlNQoOYx7GUMF/aaJMA=,tag:w7OywNVikOPfaYg2Y4HO1w==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.3"
+	}
+}

--- a/secrets/gcp_service_account.json
+++ b/secrets/gcp_service_account.json
@@ -1,0 +1,30 @@
+{
+	"type": "ENC[AES256_GCM,data:xZAlBNI+khpEBFwtLFop,iv:/Fz8+vapTZQe96muGTmXzL92FNWhZ1RAe+tYSYCg/ko=,tag:fhb+CcrQ/zoJ/CA5oq0Bdg==,type:str]",
+	"project_id": "ENC[AES256_GCM,data:eZ1GAR0bsbKaksRAYWQE,iv:f5KkTj6v7D0TPdhJwcyE9C+SbPPc7Wp1nDgRoGfZVyk=,tag:zkxE1xviZNDyAh5dszlNTQ==,type:str]",
+	"private_key_id": "ENC[AES256_GCM,data:eoX6d6Ze4mFaATp43shuW/3Og01MsEKKK8aQxzn1gxbPPT/Jjaskqg==,iv:AeSgkysVDLPWSVv0v0Mc8DHW++VCbxEb8cCPslRqYO4=,tag:Ki5aPNxelwjAbjNaZql7vA==,type:str]",
+	"private_key": "ENC[AES256_GCM,data:Qvozfvs45yaU++eYppsswcccfkjF0lrLcjTBVY4vtjVmSq8l1mOeCY7r4FimDp7tjVEzAFULptEwKTRuiVWeSI+/k44ZNJlZKB1Vt7ZLj/vcGyy+pPoZrs287Di1uGvVdQ/F691pT+C2jC94q8pUux2dRx1vgSuelKf/SLar9i213o0NyYujlYW4iKFR2Rd+wsWtHhAkrCueE3Wz0o2oMCbwzmcG8poUDll8l3127q9wygX0txOCcjd2AZA7XunVDTYGPLwZr1otOJY+ducLtTiBzIO20gLPzlnzFxVAQrj2FEBVNnGz5NU8Bo/jXZ/de2TwPQLb987xGQlNk3iK7Tmxk3bUrHnA40zLrjkmoyk1NekBlvYm6aURiELNJh2ZLAK0nw+dFaCW72ubNnmMg7jZSCYdDS/bIypA5GCN7BqTHLLKtaBIsmPmkH+n1LRTp5pReA24P1BBRHqkcs6vLBQMc12eFInOlamaAuXWdOx/63gQeZ23In25IRU+DIIcniPI5M0DJs3TzCnAXejYGILsxhEUFScIsnBJOEozuuCKpOVwJ2rDDkK4mz8aktlYadRu/kyHXJatF6V0RS6skE1/uke8jqk9sNHC2H5lsFolVWrnNCyfmlFuzeTi52Ch3ZZZmHu2+AwZ+V/bbgrcR2ywHEXortTfm6PamvaiBxleoJwiGyBd7KuKWvz1hxHHXmjTNyGKox9UWMUQnM/asOZBvfYniWUtZ+I3nI1mLkEUlH0mOvDcAl6723N4VuneXsigtHRpBiChS3qk1biq127tGwAocvGyv6UTqtvj5+N3+eOwc3Rj61FzzDsIL4A+imxyOb5V0gM0Kvwf3eJfDHxQWDP1v6R8jL8BoJxYLMbr2ar6Jmh6eGei2BrTEI47Jk3jiwWfvdw0qHv4JJu0QiapT/7/5fAG6rreBCsSZC9Tyst1fBUUXGQcY+Vyjxtrv+BXquKRnbK0TxKphY3vWMtwFI+I9ougG9fOrr9iPYU2HV1TVXvyqw3u9xJeYbBrcsqngJfFXdGjgVkQ+j+LYLbYS7mN2640y94okF/0mNgPrxmZILULhDwi9zhE88g4YJw2XfGaT4nM7or/QL29mnPiG6sC977ltmTAi1isi7gWikWEarAsuzLrtcbPg2Vt5lBM1S4gGfxffd5Tml+e4gvgp/PuKcAhKJyC09K77t91Z5btOhKig342PdZr2CNPCo2JWA69dn6GV/M9Ki18clH2kZzKdOJkTKKNOfwL3T9XS6UVYmIherHwMWmWdJBRlJnojTtweTH/w3EFw5sHOccbRROS9Cv6VLvxYWtaYKDiPls4D5+DYqyDbCe0O9jC89YA45w6jvsJ1Tdt9ZzPVXjeZrXiRz6IA/1fLvW1BkWN690YxAurx6AcJ9rFd0Zj9wl84UlB32/w6HPX2mIj+4B7FwvKWydA8lINL/22+0DUOE9WuImb86V7ulw2onJ1Ibh3h6vSWtMyapiyV3dPf62PDLvg4Yo2fjLOP6TZ6Z9M15xYRLN10Jy2vuefHZSY4GHrAxUe1Hgd9DOCApn0wo6MfG5Hu0eruZjSiRVMt3JvHnMVJQkScD2kBPQ/TxxaAVewQ+uelsTl5fA1xKbruYRNYy9m6O0PqrPp8QZvTFH7w4sKq5Ua2jmu+Td/bDx0wWuJR/ccyqaFJhnV/8VbeevFCd3xBPJMPeZnEHt0VjbZ13c4VxtaMsdCZ7VO73E+9a8OqSUMSHLPOW3KVrtdaKx+5ZWHB6T3IHZsx2MKIXkfQkgzhkxiQ65Qy5fRJFMZkBhwhSkajsz7gO+PbTmFumRahFmVXlVAZz2YXgrVtR+xXcK8X0J4UF0A4qHOtrfT+qiUIiDGlcKHLi2E9y0SRLO24OWsQmlIVO60YNrhGLzLssHz56n/mP0x2qz3Vrc54mxKQZqEwrVLfHVmEt9LNcz5+ThdUQzdp3xiW+eZX1ZhZGs0a3oQagZ1tZuC5/lwTb1Ny19xMSKORGyW8LCDjM1eJm0BHdyTnHZbL+qd1zkJrbxzAEFWPr9KZrOTjYUZO8YZSQ1S3ulfmYBzNfVxDdtHzz8HbjEVffdiDSjEBAwQiOA+2iZgJUJsg9WXF5+xvYgaAaWi5qZX9AR5uVprN4g967oLXv7eOXLxlYSl//oUHq+FEwaXz81WhUccHxzc6PL9TML+LOWIj33VeblVffZ4DQJ54t8OhzzWDxB71D0xJcyhLYARD2oeZgX40TltUW7VJbijxMS1w2uTlDs00GDWJMNg80OE,iv:CO5ws+O8k0BegLrmk+L3r9Cw8tUgrSXF1KITVEfJ4qg=,tag:ash9KWfi1xf8SfGUL9ezyQ==,type:str]",
+	"client_email": "ENC[AES256_GCM,data:PrKEKuFS24PBLbDsPmhMKE9wCP2fuDKtL1sRAn6eL7fMGR58w7dNzo+TPntmVwsPe4QDYuuDhWB9tYs=,iv:qaX2csfgqBXsRTLhIU0RJ0FACX7dF3+JlpvU7wdyBgI=,tag:7StZB/sMYRzmlkuqkWcSmA==,type:str]",
+	"client_id": "ENC[AES256_GCM,data:sBknByDiaAibWbfSJzLaEoi1/+0F,iv:EHcOikMkjsKYZuvZIlmkKITkbanHXWsu+quXxrD+hR8=,tag:P6X+dpjwhFWhQOc7M0ozTA==,type:str]",
+	"auth_uri": "ENC[AES256_GCM,data:F1W3GgJgidRI+mL/yAOTCwWNX5P/5eTeMtWVGrbLywh3sfEtDLwVD6M=,iv:YOboRTCx0ZWZvgaKMKLanO1lYgu4cLUbjO4iNHp13h8=,tag:tm9TpdSEDuW2gU20K5mB7Q==,type:str]",
+	"token_uri": "ENC[AES256_GCM,data:wyJ52gpJZJ0oGAlJJZQ2A3+G2kqJ+Ug9Re14s5ckh+XoFl0=,iv:BK6PuXn17LN9ynS4NWRTfUm0qJ6NEq9Bta+XsWHn8QQ=,tag:NfTqORrLk2bxP9RcYrV60w==,type:str]",
+	"auth_provider_x509_cert_url": "ENC[AES256_GCM,data:SmAUeb11KNVFkZAqza7B/+5u1GaDDWVqO+XyE6hp0oV52OBVc7Zklg2s,iv:VsAketVLWwEU4SjfEhZnqpNRZp8iuzVWiC2ryCKc0Gg=,tag:Y9Sq2VzNhK4M3sNB/esekQ==,type:str]",
+	"client_x509_cert_url": "ENC[AES256_GCM,data:2wETmkIJOBU947XIbIoXRCrM35QLJn8wdsd3dvPTmOne1nsOKcF3I9Ir5isiDcMMS8MLe2UW+qRpEg1Vtnin2XLKc2NGupbzr2Tw6HRKCoh53Hz45QrNc/xLHNskbBEc8SgZlY7EO2cjwgdACL+J,iv:dj+1dp1uizCUhyFb4h9pD/DAa8AQgXpqgpJNYdkELG4=,tag:lBr9Z9qIxEqhjCCGSvLxGA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+				"created_at": "2022-09-02T10:12:57Z",
+				"enc": "CiQA4OM7eJqrotuuh9M+P0pLBoIH1adjie2xrBjhH+A+7LSVCKUSSQDuy/p8DspLYeti5eFjEtCiwikD6EV7tz9SG0aLThdY3Zt38D2yWpxcd3TAI1NPJK4v+/+Br4DGIPZfDrsDP5wxCjZWwIfpNoo="
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-09-02T10:12:57Z",
+		"mac": "ENC[AES256_GCM,data:gIJBxo05tHu9ROySmiJj4uz1ifeQMO8LJ9kJFQChA03OJV5X3rwIIoL3QTOAW1AICU7HDoNOk/pO4Khk8I+BLhfpmNR+JXiL6iQkDYGSygVmfwU6ujbgTLRAB34HiQCuqh25GN20Op6y+83q+HXtAIUU3fYvZVoq366KoHclU2g=,iv:s0t1jyNjGozlVTV0zuVCoeuFCMSTRVSS5XwR9yeOxUE=,tag:ugNbOGzqLR3KC4YwkjAajg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.3"
+	}
+}

--- a/secrets/geekbot_api_token.json
+++ b/secrets/geekbot_api_token.json
@@ -1,0 +1,21 @@
+{
+	"geekbot_api_token": "ENC[AES256_GCM,data:MUOMKrcAQlAZ0Btr3JpghhVMTTlAX++5PNg4,iv:8/18IhReYml1lRvFJS6m6sckDSMj+i4rqOCNxMIVafo=,tag:JLjJ0oVTtVzg6G26bG73hw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+				"created_at": "2022-09-02T10:13:07Z",
+				"enc": "CiQA4OM7eGhdpE6UkLdVdVH+ILrZzT3CSPPZenTprR/PFnJYSlQSSQDuy/p8ihvZ76TQQWguZ7Uvik+Yd3MCM6SA4Z2TjPTWxeEprvSyC4kP4KcxNlpd/8wyr+lZspV7PFzMVhJViIKd00oiVJ/BohI="
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-09-02T10:13:08Z",
+		"mac": "ENC[AES256_GCM,data:s7l6yzMO6RbvcBY04svC4/JGxtjTpCsZfgrLprPQep9gTjKevzPAlf7vIos9tOousQpth5f0eKTSH3uyh1FiStjfsmOKOuriuEQcCKvBy+b4Dz0+FziLiohMH9Jz91lqAyRMvS+b7Sri3eHxaaEy/as6tee7iguXLrrSkUdcciM=,iv:Fv3t/HLtQGA84WCnGuYd3xcFLykoiwI4n57iRixD0yo=,tag:kRA6Zg1ze+QOuPvweZEpDw==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.3"
+	}
+}

--- a/secrets/slack_bot_token.json
+++ b/secrets/slack_bot_token.json
@@ -1,19 +1,19 @@
 {
-	"slack_bot_token": "ENC[AES256_GCM,data:TED8eMMLoXmPtl+6oGYZk9BC4/kymiGPORd9CgIhvaGRhUV+eTSZ57uVipnNPRJv+TGhj1PDfR8=,iv:2S7an5qs05k8UKsCX5V9axMQES7jqljJkHDBLadIZqQ=,tag:ARO0QH6/nwRA8JQnzThmAg==,type:str]",
+	"slack_bot_token": "ENC[AES256_GCM,data:fO0L2U0v+LF5oFG5vUf0oarxPxi8rc7nRAf8yBE5eVwcK/udWN7NnhJXqs4oMAk677vgVQhKdik=,iv:/7gNieh6LEZum2XFTFLxP888j5u0zVQIzuBmX550sBw=,tag:AnhV2Y0hGLWclmCJMVbitA==,type:str]",
 	"sops": {
 		"kms": null,
 		"gcp_kms": [
 			{
 				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
-				"created_at": "2022-09-02T10:13:20Z",
-				"enc": "CiQA4OM7eAr0hILIMTGizkgGd1kOcWQdU2n2To80gqUL6mEz/jISSQDuy/p89KNh7EW1eSUTcIdwO+C7t2A5byYh7dm86HP2OEho0+MS4xJBtvWg5PAFPQExpcofSBH+Y3wuulhZPsppuM/BTyPnpOo="
+				"created_at": "2022-09-02T11:55:51Z",
+				"enc": "CiQA4OM7eJPsJ71iPzge8Rxhoup47Yog+XEXs0UleE5HHFr1ihgSSQDuy/p8On10z7gOVCHUqtKHIK7+uw4Wk88gRG+NbtMD7seDTUUH55FEon4mx0ZZdMpDi5nTtXDdexP47vGCFMY5Thy+hqJYkB0="
 			}
 		],
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2022-09-02T10:13:20Z",
-		"mac": "ENC[AES256_GCM,data:ci4x5ZgUlcGUICr63Kh+3RGduHpyHVTOmQXjogry83Y/Onim8reJuSnqcqCHRn8hVK7/a4MqoQ/Y6SJXn4fFeJ1y2ysIq+W4F08DasyAoxnzfZZ5XB2w1urEXMVlama7CWf6twzvjErCTmST9BaO6hkFKe4DxHFddOJCgMuVyME=,iv:g/Xmkq9C90bk8KaH1+/DFODczQU9bOW0XU2bn9BaazA=,tag:aMkppd3MtZg/dhi5oPoOEA==,type:str]",
+		"lastmodified": "2022-09-02T11:55:52Z",
+		"mac": "ENC[AES256_GCM,data:Cx6D5bsU+u3/B83A5U7w+CmYYli2zm+UUJkYQgsfJ5ptsJY1i8bGfUhsjkX/vNysJ9kMRCAQrPGAsYTmu5HTsGkJr6YH97StMJ4g6w2KpzgQeM0UYwLkbk0Z0KcSYKcGc9G9EgST0bA+EAQbLYyb0nYet9mSBuxhFnsn6kvP5Sg=,iv:Xr5Gayp18f936LHSmC6PZrB2iy054wzwoMkl4pZpEGs=,tag:FUaOcPWXfDrfkfMAm2J1GQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.3"

--- a/secrets/slack_bot_token.json
+++ b/secrets/slack_bot_token.json
@@ -1,0 +1,21 @@
+{
+	"slack_bot_token": "ENC[AES256_GCM,data:TED8eMMLoXmPtl+6oGYZk9BC4/kymiGPORd9CgIhvaGRhUV+eTSZ57uVipnNPRJv+TGhj1PDfR8=,iv:2S7an5qs05k8UKsCX5V9axMQES7jqljJkHDBLadIZqQ=,tag:ARO0QH6/nwRA8JQnzThmAg==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": [
+			{
+				"resource_id": "projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs",
+				"created_at": "2022-09-02T10:13:20Z",
+				"enc": "CiQA4OM7eAr0hILIMTGizkgGd1kOcWQdU2n2To80gqUL6mEz/jISSQDuy/p89KNh7EW1eSUTcIdwO+C7t2A5byYh7dm86HP2OEho0+MS4xJBtvWg5PAFPQExpcofSBH+Y3wuulhZPsppuM/BTyPnpOo="
+			}
+		],
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-09-02T10:13:20Z",
+		"mac": "ENC[AES256_GCM,data:ci4x5ZgUlcGUICr63Kh+3RGduHpyHVTOmQXjogry83Y/Onim8reJuSnqcqCHRn8hVK7/a4MqoQ/Y6SJXn4fFeJ1y2ysIq+W4F08DasyAoxnzfZZ5XB2w1urEXMVlama7CWf6twzvjErCTmST9BaO6hkFKe4DxHFddOJCgMuVyME=,iv:g/Xmkq9C90bk8KaH1+/DFODczQU9bOW0XU2bn9BaazA=,tag:aMkppd3MtZg/dhi5oPoOEA==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.3"
+	}
+}

--- a/src/calendar/gcal_api_auth.py
+++ b/src/calendar/gcal_api_auth.py
@@ -2,31 +2,43 @@
 Authenticate with Google's Calendar API using a Service Account
 """
 import json
-import os
 import sys
-from tempfile import NamedTemporaryFile
+from pathlib import Path
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from loguru import logger
 
+from ..encryption.sops import get_decrypted_file
+
 
 class GoogleCalendarAPI:
     """Interact with the Google Calendar API"""
 
     def __init__(self, scopes=["https://www.googleapis.com/auth/calendar"]):
-        self.calendar_id = os.environ["CALENDAR_ID"]
-        self.service_account_key = json.loads(os.environ["GCP_SERVICE_ACCOUNT_KEY"])
         self.scopes = scopes
+
+        # Set filepaths
+        project_path = Path(__file__).parent.parent.parent
+        self.secrets_path = project_path.joinpath("secrets")
+
+        # Read in calendar ID
+        with get_decrypted_file(self.secrets_path.joinpath("calendar_id.json")) as df:
+            with open(df) as f:
+                contents = json.load(f)
+
+        self.calendar_id = contents["calendar_id"]
 
     def authenticate(self):
         """Return an authenticated instance of Google's Calendar API"""
-        with NamedTemporaryFile(mode="w") as service_account_file:
-            json.dump(self.service_account_key, service_account_file)
-            service_account_file.flush()
+        gcp_service_account_file = self.secrets_path.joinpath(
+            "gcp_service_account.json"
+        )
+
+        with get_decrypted_file(gcp_service_account_file) as decrypted_file:
             creds = service_account.Credentials.from_service_account_file(
-                service_account_file.name
+                decrypted_file.name
             )
 
         creds = creds.with_scopes(self.scopes)

--- a/src/encryption/sops.py
+++ b/src/encryption/sops.py
@@ -1,0 +1,71 @@
+import json
+import os
+import subprocess
+import tempfile
+from contextlib import contextmanager
+
+
+def assert_file_exists(filepath):
+    """Assert a filepath exists, raise an error if not. This function is to be used for
+    files that *absolutely have to exist* in order to successfully run the code, such
+    as, encrypted secret files
+
+    Args:
+        filepath (str): Absolute path to the file that is to be asserted for existence
+    """
+    if not os.path.isfile(filepath):
+        raise FileNotFoundError(f"File not found at following location: {filepath}")
+
+
+@contextmanager
+def get_decrypted_file(original_filepath):
+    """
+    Assert that a given file exists. If the file is sops-encryped, we provide secure,
+    temporarily decrypted contents of the file. We raise an error if we do not find the
+    sops key when we expect to, in case the decrypted contents have been leaked via
+    version control. We expect to find the sops key in a file if the filepath contains
+    the word "secrets". If the file is not encrypted, we return the original filepath.
+
+    Args:
+        original_filepath (path object): Absolute path to a file to perform checks on
+            and decrypt if it's encrypted
+
+    Yields:
+        (path object): EITHER the absolute path to a tempfile containing the
+            decrypted contents, OR the original filepath. The original filepath is
+            yielded if the file is not valid JSON, or does not contain 'secrets'.
+    """
+    assert_file_exists(original_filepath)
+    filename = os.path.basename(original_filepath)
+    _, ext = os.path.splitext(filename)
+
+    # First check for "secrets" in the filename
+    if "secrets" in filename:
+        # Then check the file is valid JSON
+        with open(original_filepath) as f:
+            try:
+                content = json.load(f)
+            except json.JSONDecodeError:
+                raise json.JSONDecodeError(
+                    "We expect encrypted files to be valid JSON files.", "", 0
+                )
+
+        # Now check for the `sops` key, indicating that it is encrypted
+        if "sops" not in content:
+            raise KeyError(
+                "Expecting to find the `sops` key in this encrypted file - but it "
+                + "wasn't found! Please regenerate the secret in case it has been "
+                + f"checked into version control and leaked!\n{original_filepath}"
+            )
+
+        # Decrypt the file contents with sops into a temp file
+        with tempfile.NamedTemporaryFile() as f:
+            subprocess.check_call(
+                ["sops", "--output", f.name, "--decrypt", original_filepath]
+            )
+            yield f.name
+
+    else:
+        # This file does not have "secrets" in it's name, therefore does not need to be
+        # decrypted. Yield the original filepath unchanged.
+        yield original_filepath

--- a/src/encryption/sops.py
+++ b/src/encryption/sops.py
@@ -36,11 +36,9 @@ def get_decrypted_file(original_filepath):
             yielded if the file is not valid JSON, or does not contain 'secrets'.
     """
     assert_file_exists(original_filepath)
-    filename = os.path.basename(original_filepath)
-    _, ext = os.path.splitext(filename)
 
-    # First check for "secrets" in the filename
-    if "secrets" in filename:
+    # First check for "secrets" in the filepath
+    if "secrets" in str(original_filepath):
         # Then check the file is valid JSON
         with open(original_filepath) as f:
             try:

--- a/src/geekbot/get_slack_usergroup_members.py
+++ b/src/geekbot/get_slack_usergroup_members.py
@@ -1,19 +1,31 @@
 """
 Functions to get Slack members who are in a given usergroup
 """
-import os
+import json
 from collections import OrderedDict
+from pathlib import Path
 
 from loguru import logger
 from slack_sdk import WebClient
+
+from ..encryption.sops import get_decrypted_file
 
 
 class SlackUsergroupMembers:
     """Find the members of a given Slack usergroup"""
 
     def __init__(self):
+        # Set filepaths
+        project_path = Path(__file__).parent.parent.parent
+        secrets_path = project_path.joinpath("secrets")
+
+        # Get Slack bot token
+        with get_decrypted_file(secrets_path.joinpath("slack_bot_token.json")) as df:
+            with open(df) as f:
+                contents = json.load(f)
+
         # Instantiate a SLACK API client
-        self.client = WebClient(token=os.environ["SLACK_BOT_TOKEN"])
+        self.client = WebClient(token=contents["slack_bot_token"])
 
     def _get_usergroup_id(self, usergroup_name):
         """Retrieve the ID of a given Slack usergroup"""


### PR DESCRIPTION
This should be more helpful for other people to run the code locally, rather than having to find and set all the correct environment variables.

### Other actions taken not reflected by changes in this PR

All existing secrets (and the run-slack-bot environment) have been deleted from the repository and replaced with a single GCP KMS Decryptor Key for use with `sops`. This is the same way we run the hub deployment workflow over in `infrastructure`.