### PR TITLE
When using create-events-rolling.py locally, ask for confirmation before creating the event

### DIFF
--- a/src/calendar/create_events_rolling_update.py
+++ b/src/calendar/create_events_rolling_update.py
@@ -127,7 +127,7 @@ class CreateNextEvent:
         events = self._get_upcoming_events(role)
 
         # Find the last event in this series
-            last_event = events[-1]
+        last_event = events[-1]
 
         # Extract the relevant metadata from the last event in the series
         last_event_end_date = last_event.get("dateTime", last_event["end"].get("date"))
@@ -203,21 +203,18 @@ class CreateNextEvent:
         print(body["start"]["date"], "->", body["end"]["date"], ":", body["summary"])
 
         if not ci:
-            confirm = Confirm.ask(
-                "Create the above event?",
-                default=False,
-            )
+            confirm = Confirm.ask("Create the above event?", default=False)
 
         if ci or confirm:
-        try:
+            try:
                 logger.info("Creating event...")
 
-            # Create the event
-            self.gcal_api.events().insert(
-                calendarId=self.calendar_id, body=body
-            ).execute()
-        except HttpError as error:
-            logger.error(f"An error occured: {error}")
+                # Create the event
+                self.gcal_api.events().insert(
+                    calendarId=self.calendar_id, body=body
+                ).execute()
+            except HttpError as error:
+                logger.error(f"An error occured: {error}")
         elif not ci and not confirm:
             logger.info("Ok! Exiting without creating an event")
 

--- a/src/calendar/create_events_rolling_update.py
+++ b/src/calendar/create_events_rolling_update.py
@@ -127,16 +127,21 @@ class CreateNextEvent:
         events = self._get_upcoming_events(role)
 
         # Find the last event in this series
-        if role == "meeting-facilitator":
             last_event = events[-1]
-        elif role == "support-steward":
-            # We use [-2] here because the support steward role overlaps by 2 two weeks
-            last_event = events[-2]
 
         # Extract the relevant metadata from the last event in the series
         last_event_end_date = last_event.get("dateTime", last_event["end"].get("date"))
         last_event_end_date = datetime.strptime(last_event_end_date, "%Y-%m-%d")
         last_member = last_event.get("summary", "").split(":")[-1].strip()
+
+        if role == "support-steward":
+            # We use [-2] here because the support steward role overlaps by 2 two weeks. So for the last evet dates,
+            # we need the second to last event in the list
+            last_event = events[-2]
+            last_event_end_date = last_event.get(
+                "dateTime", last_event["end"].get("date")
+            )
+            last_event_end_date = datetime.strptime(last_event_end_date, "%Y-%m-%d")
 
         # Calculate the next team member to serve in this role
         last_member_index = next(


### PR DESCRIPTION
Adds a prompt to confirm the new event is correct before creating it in the calendar

Also fixes a bug the caused the wrong team member to be assigned in the support steward case