### PR TITLE
Ensure we pull the next team member from the calendar events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ google-auth-httplib2 = "^0.1"
 google-auth-oauthlib = "^0.5"
 
 [tool.poetry.scripts]
+list-entrypoints = "src.list_entrypoints:main"
 list-members = "src.geekbot.get_slack_usergroup_members:main"
 update-team-role = "src.geekbot.update_team_roles:main"
 create-standup = "src.geekbot.create_geekbot_standup:main"

--- a/src/calendar/create_events_bulk.py
+++ b/src/calendar/create_events_bulk.py
@@ -167,7 +167,7 @@ def create_bulk_events(role, n_events=None, ref_date=None, member=None):
             )
 
     for event in events:
-        print(f"{event['start']['date']} -> {event['end']['date']}: {event['summary']}")
+        event_handler.log_event_metadata(event)
 
     confirm = Confirm.ask("Create these events?", default=False)
 

--- a/src/calendar/create_events_rolling_update.py
+++ b/src/calendar/create_events_rolling_update.py
@@ -25,9 +25,7 @@ def create_next_event(role):
     event_handler = CalendarEventHandler(role, usergroup_name)
 
     next_event_info = event_handler.calculate_next_event_data()
-    print(
-        f"{next_event_info['start']['date']} -> {next_event_info['end']['date']}: {next_event_info['summary']}"
-    )
+    event_handler.log_event_metadata(next_event_info)
 
     if not ci:
         confirm = Confirm.ask("Create the above event?", default=False)

--- a/src/calendar/delete_events_bulk.py
+++ b/src/calendar/delete_events_bulk.py
@@ -52,7 +52,7 @@ def main():
     logger.info(f"{len(events)} events for {args.role.replace('-', ' ').title()} found")
 
     for event in events:
-        print(f"{event['start']['date']} -> {event['end']['date']}: {event['summary']}")
+        event_handler.log_event_metadata(event)
 
     # Prompt for confirmation
     confirm = Confirm.ask("Delete all these events?", default=False)

--- a/src/calendar/event_handling.py
+++ b/src/calendar/event_handling.py
@@ -173,7 +173,10 @@ class CalendarEventHandler:
             ROLE_CYCLES[self.role]["index"] - 1,
             ROLE_CYCLES[self.role]["index"],
         ):
-            self.log_event_metadata(events[indx])
+            try:
+                self.log_event_metadata(events[indx])
+            except IndexError:
+                pass
 
         try:
             next_event = events[ROLE_CYCLES[self.role]["index"]]

--- a/src/calendar/event_handling.py
+++ b/src/calendar/event_handling.py
@@ -21,12 +21,14 @@ ROLE_CYCLES = {
         "frequency": 1,  # Monthly
         "period": 1,
         "n_events": 12,  # Equates to 1 year
+        "index": 1,  # Index to extract next event from
     },
     "support-steward": {
         "unit": "days",
         "frequency": 14,  # Fortnightly
         "period": 28,  # 4 weeks
         "n_events": 26,  # Equates to 1 year
+        "index": 2,  # Index to extract next event from
     },
 }
 
@@ -156,6 +158,28 @@ class CalendarEventHandler:
             next_member_index = 0 + (offset % len(self.usergroup_members))
 
         return list(self.usergroup_members)[next_member_index]
+
+    def find_next_team_member_from_calendar(self):
+        """Extract the next team member to serve in a role from a calendar event
+
+        Returns:
+            str: The name of the next team member to serve in a role
+        """
+        events = self.get_upcoming_events(nMaxResults=5)
+
+        for indx in (
+            ROLE_CYCLES[self.role]["index"] - 1,
+            ROLE_CYCLES[self.role]["index"],
+        ):
+            self._log_event_metadata(events[indx])
+
+        try:
+            next_event = events[ROLE_CYCLES[self.role]["index"]]
+            next_member = next_event.get("summary", "").split(":")[-1].strip()
+        except IndexError:
+            next_member = None
+
+        return next_member
 
     def get_first_event(self):
         """Extract the metadata of the first event in a series. Metadata extracted are: the

--- a/src/calendar/event_handling.py
+++ b/src/calendar/event_handling.py
@@ -127,7 +127,8 @@ class CalendarEventHandler:
         return next_event_start_date, next_event_end_date
 
     def _find_next_team_member_manually(self, last_member, offset=0):
-        """Find the next team member to serve in a given role
+        """Find the next team member to serve in a given role by iterating
+        through a list of team members
 
         Args:
             last_member (str): The last team member serving in the role
@@ -164,6 +165,8 @@ class CalendarEventHandler:
             tuple(date obj, str): The end date of the first event in the series, and the team
                 member who served in the role during that event
         """
+        logger.info("Extracting metadata for first event in the series...")
+
         # Find upcoming events. Set nMaxResults to 3 here since that should return
         # one Meeting Facilitator event and two Support Steward events.
         events = self.get_upcoming_events(nMaxResults=3)
@@ -180,8 +183,9 @@ class CalendarEventHandler:
         first_member = first_event.get("summary", "").split(":")[-1].strip()
 
         if self.role == "support-steward":
-            # We use [1] here because the support steward role overlaps by 2 two weeks. So for the team member
-            # serving in the role, we need to use the next event to calculate where to begin iterating from.
+            # We use [1] here because the support steward role overlaps by 2 two
+            # weeks. So for the team member serving in the role, we need to use
+            # the next event to calculate where to begin iterating from.
             first_event = events[1]
             self._log_event_metadata(first_event)
 

--- a/src/calendar/event_handling.py
+++ b/src/calendar/event_handling.py
@@ -173,10 +173,6 @@ class CalendarEventHandler:
         self._log_event_metadata(first_event)
 
         # Extract the relevant metadata from the first event in the series
-        first_event_start_date = first_event.get(
-            "dateTime", first_event["start"].get("date")
-        )
-        first_event_start_date = datetime.strptime(first_event_start_date, "%Y-%m-%d")
         first_event_end_date = first_event.get(
             "dateTime", first_event["end"].get("date")
         )
@@ -188,6 +184,7 @@ class CalendarEventHandler:
             # serving in the role, we need to use the next event to calculate where to begin iterating from.
             first_event = events[1]
             self._log_event_metadata(first_event)
+
             first_member = first_event.get("summary", "").split(":")[-1].strip()
 
         return first_event_end_date, first_member
@@ -216,10 +213,6 @@ class CalendarEventHandler:
             self._log_event_metadata(last_event)
 
         # Extract the relevant metadata from the last event in the series
-        last_event_start_date = last_event.get(
-            "dateTime", last_event["start"].get("date")
-        )
-        last_event_start_date = datetime.strptime(last_event_start_date, "%Y-%m-%d")
         last_event_end_date = last_event.get("dateTime", last_event["end"].get("date"))
         last_event_end_date = datetime.strptime(last_event_end_date, "%Y-%m-%d")
         last_member = last_event.get("summary", "").split(":")[-1].strip()
@@ -230,6 +223,7 @@ class CalendarEventHandler:
             last_event = events[-2]
             if not suppress_logs:
                 self._log_event_metadata(last_event)
+
             last_event_end_date = last_event.get(
                 "dateTime", last_event["end"].get("date")
             )

--- a/src/calendar/event_handling.py
+++ b/src/calendar/event_handling.py
@@ -165,6 +165,8 @@ class CalendarEventHandler:
         Returns:
             str: The name of the next team member to serve in a role
         """
+        logger.info("Extracting next team member from the calendar...")
+
         events = self.get_upcoming_events(nMaxResults=5)
 
         for indx in (

--- a/src/calendar/event_handling.py
+++ b/src/calendar/event_handling.py
@@ -90,7 +90,7 @@ class CalendarEventHandler:
 
         return next_event_start_date, next_event_end_date
 
-    def _find_next_team_member(self, last_member, offset=0):
+    def _find_next_team_member_manually(self, last_member, offset=0):
         """Find the next team member to serve in a given role
 
         Args:
@@ -358,7 +358,7 @@ class CalendarEventHandler:
         if not suppress_logs:
             logger.info("Generating metadata for next event...")
 
-        next_member = self._find_next_team_member(last_member, offset)
+        next_member = self._find_next_team_member_manually(last_member, offset)
         start_date, end_date = self._calculate_next_event_dates(last_end_date, offset)
 
         # This represents the minimum amount of information to POST to the Google

--- a/src/calendar/event_handling.py
+++ b/src/calendar/event_handling.py
@@ -58,7 +58,7 @@ class CalendarEventHandler:
 
         self.calendar_id = contents["calendar_id"]
 
-    def _log_event_metadata(self, event_info):
+    def log_event_metadata(self, event_info):
         """Send metadata for a calendar event to the logger
 
         Args:
@@ -173,7 +173,7 @@ class CalendarEventHandler:
             ROLE_CYCLES[self.role]["index"] - 1,
             ROLE_CYCLES[self.role]["index"],
         ):
-            self._log_event_metadata(events[indx])
+            self.log_event_metadata(events[indx])
 
         try:
             next_event = events[ROLE_CYCLES[self.role]["index"]]
@@ -199,7 +199,7 @@ class CalendarEventHandler:
 
         # Find the first event in the series
         first_event = events[0]
-        self._log_event_metadata(first_event)
+        self.log_event_metadata(first_event)
 
         # Extract the relevant metadata from the first event in the series
         first_event_end_date = first_event.get(
@@ -213,7 +213,7 @@ class CalendarEventHandler:
             # weeks. So for the team member serving in the role, we need to use
             # the next event to calculate where to begin iterating from.
             first_event = events[1]
-            self._log_event_metadata(first_event)
+            self.log_event_metadata(first_event)
 
             first_member = first_event.get("summary", "").split(":")[-1].strip()
 
@@ -240,7 +240,7 @@ class CalendarEventHandler:
         # Find the last event in this series
         last_event = events[-1]
         if not suppress_logs:
-            self._log_event_metadata(last_event)
+            self.log_event_metadata(last_event)
 
         # Extract the relevant metadata from the last event in the series
         last_event_end_date = last_event.get("dateTime", last_event["end"].get("date"))
@@ -252,7 +252,7 @@ class CalendarEventHandler:
             # we need the second to last event in the list
             last_event = events[-2]
             if not suppress_logs:
-                self._log_event_metadata(last_event)
+                self.log_event_metadata(last_event)
 
             last_event_end_date = last_event.get(
                 "dateTime", last_event["end"].get("date")

--- a/src/geekbot/update_team_roles.py
+++ b/src/geekbot/update_team_roles.py
@@ -97,8 +97,17 @@ class TeamRoles:
         through 2i2c team members
         """
         # Find the current team member and next team member to serve in a role
-        _, current_member = self.event_handler.get_first_event()
-        next_member = self.event_handler._find_next_team_member_manually(current_member)
+        next_member = self.event_handler.find_next_team_member_from_calendar()
+
+        if next_member is None:
+            logger.warning(
+                "Couldn't extract the next team member from the calendar. "
+                "Falling back onto iteration."
+            )
+            _, current_member = self.event_handler.get_first_event()
+            next_member = self.event_handler._find_next_team_member_manually(
+                current_member
+            )
 
         logger.info(f"Next {' '.join(self.role.split('-')).title()}: {next_member}")
 

--- a/src/geekbot/update_team_roles.py
+++ b/src/geekbot/update_team_roles.py
@@ -98,7 +98,7 @@ class TeamRoles:
         """
         # Find the current team member and next team member to serve in a role
         _, current_member = self.event_handler.get_first_event()
-        next_member = self.event_handler._find_next_team_member(current_member)
+        next_member = self.event_handler._find_next_team_member_manually(current_member)
 
         logger.info(f"Next {' '.join(self.role.split('-')).title()}: {next_member}")
 

--- a/src/list_entrypoints.py
+++ b/src/list_entrypoints.py
@@ -2,9 +2,10 @@
 Helper script to list the entrypoints and their usage/help messages
 instead of inspecting pyproject.toml or README.md by hand
 """
-import toml
 import subprocess
 from pathlib import Path
+
+import toml
 from rich import print
 
 

--- a/src/list_entrypoints.py
+++ b/src/list_entrypoints.py
@@ -1,0 +1,29 @@
+"""
+Helper script to list the entrypoints and their usage/help messages
+instead of inspecting pyproject.toml or README.md by hand
+"""
+import toml
+import subprocess
+from pathlib import Path
+from rich import print
+
+
+def main():
+    project_root = Path(__file__).parent.parent
+    pyproject_filepath = project_root.joinpath("pyproject.toml")
+    pyproject = toml.load(pyproject_filepath)
+
+    for entrypoint in pyproject["tool"]["poetry"]["scripts"].keys():
+        if entrypoint == "populate-current-roles":
+            print(f"usage: {entrypoint}")
+        else:
+            try:
+                subprocess.check_call(["poetry", "run", entrypoint, "--help"])
+            except subprocess.CalledProcessError:
+                print(f"usage: {entrypoint}")
+
+        print(f"[green bold]{80*'*'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_calendar/test_event_handling.py
+++ b/tests/test_calendar/test_event_handling.py
@@ -213,3 +213,73 @@ def test_get_first_event_support_steward(mock_upcoming_events):
 
     assert end_date == datetime(2022, 9, 21)
     assert last_member == "Person B"
+
+
+@patch("src.calendar.event_handling.CalendarEventHandler.get_upcoming_events")
+def test_find_next_team_member_from_calendar_meeting_facilitator(mock_upcoming_events):
+    test_event_handler = EventHandlerSubClass(
+        "meeting-facilitator", "meeting-facilitators"
+    )
+
+    mock_upcoming_events.return_value = [
+        {
+            "start": {"date": "2022-08-01"},
+            "end": {"date": "2022-09-01"},
+            "summary": "Meeting Facilitator: Person A",
+        },
+        {
+            "start": {"date": "2022-09-01"},
+            "end": {"date": "2022-10-01"},
+            "summary": "Meeting Facilitator: Person B",
+        },
+    ]
+
+    next_member = test_event_handler.find_next_team_member_from_calendar()
+
+    assert next_member == "Person B"
+
+
+@patch("src.calendar.event_handling.CalendarEventHandler.get_upcoming_events")
+def test_find_next_team_member_from_calendar_support_steward(mock_upcoming_events):
+    test_event_handler = EventHandlerSubClass("support-steward", "support-stewards")
+
+    mock_upcoming_events.return_value = [
+        {
+            "start": {"date": "2022-08-24"},
+            "end": {"date": "2022-09-21"},
+            "summary": "Support Steward: Person A",
+        },
+        {
+            "start": {"date": "2022-09-07"},
+            "end": {"date": "2022-10-05"},
+            "summary": "Support Steward: Person B",
+        },
+        {
+            "start": {"date": "2022-09-21"},
+            "end": {"date": "2022-10-19"},
+            "summary": "Support Steward: Person C",
+        },
+    ]
+
+    next_member = test_event_handler.find_next_team_member_from_calendar()
+
+    assert next_member == "Person C"
+
+
+@patch("src.calendar.event_handling.CalendarEventHandler.get_upcoming_events")
+def test_find_next_team_member_from_calendar_not_found(mock_upcoming_events):
+    test_event_handler = EventHandlerSubClass(
+        "meeting-facilitator", "meeting-facilitators"
+    )
+
+    mock_upcoming_events.return_value = [
+        {
+            "start": {"date": "2022-08-01"},
+            "end": {"date": "2022-09-01"},
+            "summary": "Meeting Facilitator: Person A",
+        },
+    ]
+
+    next_member = test_event_handler.find_next_team_member_from_calendar()
+
+    assert next_member is None

--- a/tests/test_calendar/test_event_handling.py
+++ b/tests/test_calendar/test_event_handling.py
@@ -94,9 +94,15 @@ def test_create_next_event_dates_support_steward_with_offset():
 
 def test_find_next_team_member_manually():
     test_event_handler = EventHandlerSubClass("support-steward", "support-stewards")
-    next_member_no_offset = test_event_handler._find_next_team_member_manually("Person B")
-    next_member_with_offset = test_event_handler._find_next_team_member_manually("Person B", 3)
-    next_member_loop_offset = test_event_handler._find_next_team_member_manually("Person B", 7)
+    next_member_no_offset = test_event_handler._find_next_team_member_manually(
+        "Person B"
+    )
+    next_member_with_offset = test_event_handler._find_next_team_member_manually(
+        "Person B", 3
+    )
+    next_member_loop_offset = test_event_handler._find_next_team_member_manually(
+        "Person B", 7
+    )
 
     assert next_member_no_offset == "Person C"
     assert next_member_with_offset == "Person F"

--- a/tests/test_calendar/test_event_handling.py
+++ b/tests/test_calendar/test_event_handling.py
@@ -92,11 +92,11 @@ def test_create_next_event_dates_support_steward_with_offset():
     case.assertCountEqual(next_event_dates, expected_event_dates)
 
 
-def test_find_next_team_member():
+def test_find_next_team_member_manually():
     test_event_handler = EventHandlerSubClass("support-steward", "support-stewards")
-    next_member_no_offset = test_event_handler._find_next_team_member("Person B")
-    next_member_with_offset = test_event_handler._find_next_team_member("Person B", 3)
-    next_member_loop_offset = test_event_handler._find_next_team_member("Person B", 7)
+    next_member_no_offset = test_event_handler._find_next_team_member_manually("Person B")
+    next_member_with_offset = test_event_handler._find_next_team_member_manually("Person B", 3)
+    next_member_loop_offset = test_event_handler._find_next_team_member_manually("Person B", 7)
 
     assert next_member_no_offset == "Person C"
     assert next_member_with_offset == "Person F"


### PR DESCRIPTION
- Attempt to pull the next team member from the calendar events. If no calendar event found, fall back onto manual iteration.
- Consolidate code that sends event metadata to the logger into a class method (increases DRY)
- Also add a helper script that lists the entrypoints and their help info so I don't have to keep checking pyproject.toml or the README