### PR TITLE
Update number of events to pull when finding next team member

### DIFF
--- a/src/calendar/event_handling.py
+++ b/src/calendar/event_handling.py
@@ -167,7 +167,7 @@ class CalendarEventHandler:
         """
         logger.info("Extracting next team member from the calendar...")
 
-        events = self.get_upcoming_events(nMaxResults=5)
+        events = self.get_upcoming_events(nMaxResults=6)
 
         for indx in (
             ROLE_CYCLES[self.role]["index"] - 1,


### PR DESCRIPTION
Ensure that enough events are pulled to cover at least 2 meeting facilitator events