### PR TITLE
Cleanup CI workflows

### DIFF
--- a/.github/workflows/meeting-facilitator.yaml
+++ b/.github/workflows/meeting-facilitator.yaml
@@ -39,11 +39,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup Python v3.9
-        uses: actions/setup-python@v4.5.0
-        with:
-          python-version: "3.9"
-
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/meeting-facilitator.yaml
+++ b/.github/workflows/meeting-facilitator.yaml
@@ -33,6 +33,8 @@ env:
 jobs:
   create-standup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/populate-current-roles.yaml
+++ b/.github/workflows/populate-current-roles.yaml
@@ -42,6 +42,8 @@ on:
 jobs:
   populate-team-roles:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/populate-current-roles.yaml
+++ b/.github/workflows/populate-current-roles.yaml
@@ -48,11 +48,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup Python v3.9
-        uses: actions/setup-python@v4.5.0
-        with:
-          python-version: "3.9"
-
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/support-steward.yaml
+++ b/.github/workflows/support-steward.yaml
@@ -72,11 +72,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup Python v3.9
-        uses: actions/setup-python@v4.5.0
-        with:
-          python-version: "3.9"
-
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:
@@ -140,11 +135,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-
-      - name: Setup Python v3.9
-        uses: actions/setup-python@v4.5.0
-        with:
-          python-version: "3.9"
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,18 +13,9 @@ jobs:
   test-code:
     runs-on: ubuntu-latest
     environment: codecov
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9", "3.10"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.5.0
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
@@ -57,7 +48,6 @@ jobs:
           coverage report && coverage xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.10'
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
This PR is motivated by the following logic:

> Whatever Python version we ask for by using the Setup Python GitHub Action is overwritten when we run `poetry install` by whichever version of Python is defined in the `pyproject.toml` file. Hence, it does not make sense to either i) define a Python version in the workflow before running `poetry install`, or ii) running tests across a matrix of Python versions.

- Removes matrix strategy for source code tests
- Removes Python setup step from all workflows
- Adds some missing permissions for GITHUB_TOKEN