### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,15 +3,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    ignore:
-      # Ignore patch upgrades to reduce noise
-      - update-types: ["version-update:semver-patch"]
-        dependency-name: "*" # Match all packages
+      interval: "monthly"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       # Ignore patch upgrades to reduce noise
       - update-types: ["version-update:semver-patch"]

--- a/.github/workflows/meeting-facilitator.yaml
+++ b/.github/workflows/meeting-facilitator.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python v3.9
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -64,7 +64,7 @@ jobs:
 
       # This action use the github official cache mechanism internally
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1.4.1
+        uses: mdgreenwald/mozilla-sops-action@v1
         with:
           version: v3.7.2
 
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python v3.9
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -129,7 +129,7 @@ jobs:
 
       # This action use the github official cache mechanism internally
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1.4.1
+        uses: mdgreenwald/mozilla-sops-action@v1
         with:
           version: v3.7.2
 

--- a/.github/workflows/populate-current-roles.yaml
+++ b/.github/workflows/populate-current-roles.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python v3.9
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -73,7 +73,7 @@ jobs:
 
       # This action use the github official cache mechanism internally
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1.4.1
+        uses: mdgreenwald/mozilla-sops-action@v1
         with:
           version: v3.7.2
 

--- a/.github/workflows/support-steward.yaml
+++ b/.github/workflows/support-steward.yaml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python v3.9
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -99,7 +99,7 @@ jobs:
 
       # This action use the github official cache mechanism internally
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1.4.1
+        uses: mdgreenwald/mozilla-sops-action@v1
         with:
           version: v3.7.2
 
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python v3.9
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4
         with:
           python-version: "3.9"
 
@@ -168,7 +168,7 @@ jobs:
 
       # This action use the github official cache mechanism internally
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1.4.1
+        uses: mdgreenwald/mozilla-sops-action@v1
         with:
           version: v3.7.2
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.5.0
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
- Check for updates monthly
- Remove `ignore` statement for GitHub Actions
- Set all dependant GitHub Actions steps in workflows to use `@v[major]` style pinning, instead of `@v[major].[minor].[patch]`