### PR TITLE
Minor tweaks to CI

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,7 +8,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-    ignore:
-      # Ignore patch upgrades to reduce noise
-      - update-types: ["version-update:semver-patch"]
-        dependency-name: "*" # Match all packages

--- a/.github/workflows/meeting-facilitator.yaml
+++ b/.github/workflows/meeting-facilitator.yaml
@@ -66,7 +66,7 @@ jobs:
 
       # This action use the github official cache mechanism internally
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1
+        uses: mdgreenwald/mozilla-sops-action@v1.4.1
         with:
           version: v3.7.2
 
@@ -131,7 +131,7 @@ jobs:
 
       # This action use the github official cache mechanism internally
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1
+        uses: mdgreenwald/mozilla-sops-action@v1.4.1
         with:
           version: v3.7.2
 

--- a/.github/workflows/populate-current-roles.yaml
+++ b/.github/workflows/populate-current-roles.yaml
@@ -75,7 +75,7 @@ jobs:
 
       # This action use the github official cache mechanism internally
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1
+        uses: mdgreenwald/mozilla-sops-action@v1.4.1
         with:
           version: v3.7.2
 

--- a/.github/workflows/support-steward.yaml
+++ b/.github/workflows/support-steward.yaml
@@ -66,7 +66,7 @@ jobs:
 
       # This action use the github official cache mechanism internally
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1
+        uses: mdgreenwald/mozilla-sops-action@v1.4.1
         with:
           version: v3.7.2
 
@@ -133,7 +133,7 @@ jobs:
 
       # This action use the github official cache mechanism internally
       - name: Install sops
-        uses: mdgreenwald/mozilla-sops-action@v1
+        uses: mdgreenwald/mozilla-sops-action@v1.4.1
         with:
           version: v3.7.2
 


### PR DESCRIPTION
- Update version of mozilla-sops-action. Hoping to rectify messages regarding out-of-date node version and deprecated set-output use.
- Relax dependabot a bit