### PR TITLE
Rename Support Steward to Triager

### DIFF
--- a/.github/workflows/populate-current-roles.yaml
+++ b/.github/workflows/populate-current-roles.yaml
@@ -3,19 +3,19 @@ name: Populate a JSON file with members currently serving in our Team Roles
 on:
   workflow_dispatch:
     inputs:
-      current-support-steward:
+      current-support-triager:
         required: true
         description: |
           The Slack display name of the team member currently serving in the Support
-          Steward role (i.e. for more than one week)
-      incoming-support-steward:
+          Triager role (i.e. for more than one week)
+      incoming-support-triager:
         required: true
         description: |
           The Slack display name of the team member most recently taking up service in
-          the Support Steward role (i.e. for less than one week)
+          the Support Triager role (i.e. for less than one week)
       usergroup-name:
         required: false
-        default: support-stewards
+        default: support-triagers
         description: |
           The Slack usergroup(s) our Team Roles are generated from. If providing multiple
           usergroups, separate them with a comma ",".
@@ -90,8 +90,8 @@ jobs:
           poetry run populate-current-roles
         env:
           CURRENT_MEETING_FACILITATOR: "${{ github.event.inputs.current-meeting-facilitator }}"
-          CURRENT_SUPPORT_STEWARD: "${{ github.event.inputs.current-support-steward }}"
-          INCOMING_SUPPORT_STEWARD: "${{ github.event.inputs.incoming-support-steward }}"
+          CURRENT_SUPPORT_TRIAGER: "${{ github.event.inputs.current-support-triager }}"
+          INCOMING_SUPPORT_TRIAGER: "${{ github.event.inputs.incoming-support-triager }}"
           USERGROUP_NAMES: "${{ github.event.inputs.usergroup-name }}"
           STANDUP_MANAGER: "${{ github.event.inputs.standup-manager }}"
 

--- a/.github/workflows/support-triager.yaml
+++ b/.github/workflows/support-triager.yaml
@@ -1,4 +1,4 @@
-name: Support Steward
+name: Support Triager
 
 on:
   workflow_dispatch:
@@ -21,14 +21,14 @@ on:
           event will be added.
       usergroup-name:
         required: false
-        default: support-stewards
+        default: support-triagers
         description: |
-          The Slack usergroup our Support Stewards are generated from
+          The Slack usergroup our Support Triagers are generated from
   schedule:
     - cron: "0 0 * * MON"  # Run at 00:00 UTC weekly on Mondays
 
 env:
-  USERGROUP_NAME: support-stewards
+  USERGROUP_NAME: support-triagers
 
 jobs:
   create-standup:
@@ -79,7 +79,7 @@ jobs:
         if: github.event_name == 'schedule' || github.event.inputs.update-roles == 'true'
         run: |
           source .venv/bin/activate
-          poetry run update-team-role support-steward
+          poetry run update-team-role support-triager
         env:
           USERGROUP_NAME: "${{ github.event.inputs.usergroup-name || env.USERGROUP_NAME }}"
 
@@ -90,10 +90,10 @@ jobs:
           add: team-roles.json
           message: "Update the Team Roles JSON file"
 
-      - name: Create a standup for the Support Steward
+      - name: Create a standup for the Support Triager
         run: |
           source .venv/bin/activate
-          poetry run create-standup support-steward
+          poetry run create-standup support-triager
 
   update-calendar:
     runs-on: ubuntu-latest
@@ -142,9 +142,9 @@ jobs:
         with:
           credentials_json: "${{ secrets.GCP_KMS_DECRYPTOR_KEY }}"
 
-      - name: Create next Support Steward event in the calendar
+      - name: Create next Support Triager event in the calendar
         run: |
           source .venv/bin/activate
-          poetry run create-next-event support-steward
+          poetry run create-next-event support-triager
         env:
           USERGROUP_NAME: "${{ github.event.inputs.usergroup-name || env.USERGROUP_NAME }}"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Slack/Geekbot/Google Calendar App to sweep through 2i2c team members, assign T
 
 ## Summary
 
-This repository is a collection of Python code that tracks which 2i2c team members are currently serving in our Team Roles (Meeting Facilitator and Support Steward).
+This repository is a collection of Python code that tracks which 2i2c team members are currently serving in our Team Roles (Meeting Facilitator and Support Triager).
 The code works out which team member is due to take over a given role, and dynamically generates Geekbot standups in Slack to visibly and explicitly notify the given team member that they are due to take over the role.
 It also creates events in the Team Roles Google Calendar to make the role changes more visible.
 
@@ -51,7 +51,7 @@ Which 2i2c teams members are serving (or have served) in a given role are stored
 We keep track of both a team member's Slack display name and user ID.
 This is because interacting with the Slack and Geekbot APIs requires the user ID, but it is more human-readable to also have the names.
 
-For the Support Steward, we track both the current and incoming team members as we have two people overlapping in this role.
+For the Support Triager, we track both the current and incoming team members as we have two people overlapping in this role.
 
 We have an extra role here called `standup_manager`.
 This is the team member who created `GEEKBOT_API_KEY` and will be added to all standups.
@@ -68,7 +68,7 @@ This is because Geekbot only provides personal API keys and these keys do not ha
         "name": "display_name",
         "id": "slack_id"
     },
-    "support_steward": {
+    "support_triager": {
         "incoming": {
             "name": "display_name",
             "id": "slack_id"
@@ -88,7 +88,7 @@ All scripts are written in Python and are located in the [`src`](src/) folder.
 ### `get_slack_usergroup_members.py`
 
 This script interacts with the Slack API to produce a dictionary of Slack users who are members of a given Slack usergroup and their IDs.
-The script requires the `usergroup_name` variable to be set, which is the name of the Slack usergroup to list members of, e.g., `meeting-facilitators` or `support-stewards`.
+The script requires the `usergroup_name` variable to be set, which is the name of the Slack usergroup to list members of, e.g., `meeting-facilitators` or `support-triagers`.
 
 The script will generate a dictionary of members of `usergroup_name` where the keys are the users' display names, and the values are their associated user IDs.
 The dictionary is ordered alphabetically by its keys.
@@ -117,7 +117,7 @@ optional arguments:
 
 ### `update_team_roles.py`
 
-This script generates the next team member to serve in a given role by iterating one place through the appropriate Slack usergroup (either `meeting-facilitators` or `support-stewards`).
+This script generates the next team member to serve in a given role by iterating one place through the appropriate Slack usergroup (either `meeting-facilitators` or `support-triagers`).
 It depends on [`get_slack_usergroup_members.py`](#get_slack_usergroup_memberspy) to pull the list of usergroup members from Slack.
 The desired usergroup to pull the members of is parsed to the script via the `USERGROUP_NAME` environment variable.
 
@@ -131,18 +131,18 @@ There are command line options to determine which role is to be updated.
 To execute, run the following command:
 
 ```bash
-poetry run update-team-role { meeting-facilitator | support-steward }
+poetry run update-team-role { meeting-facilitator | support-triager }
 ```
 
 **Help info:**
 
 ```bash
-usage: update-team-role [-h] {meeting-facilitator,support-steward}
+usage: update-team-role [-h] {meeting-facilitator,support-triager}
 
 Update our Team Roles by iterating through 2i2c team members
 
 positional arguments:
-  {meeting-facilitator,support-steward}
+  {meeting-facilitator,support-triager}
                         The role to update
 
 optional arguments:
@@ -153,7 +153,7 @@ optional arguments:
 
 This script reads in [`team-roles.json`](#team-roles-json-file-structure) after it has been modified by [`update_team_roles.py`](#update_team_rolespy) and generates a Geekbot standup to notify the incoming team member for their upcoming role.
 
-The `MeetingFacilitatorStandup` broadcasts to the `team-updates` Slack channel, and the `SupportStewardStandup` broadcasts to the `support-freshdesk` channel.
+The `MeetingFacilitatorStandup` broadcasts to the `team-updates` Slack channel, and the `SupportTriagerStandup` broadcasts to the `support-freshdesk` channel.
 The [Geekbot app](https://geekbot.com/) needs to be installed to the Slack workspace and invited to the channels to which it will broadcast.
 Command line options are provided to select which role a standup should be created for.
 
@@ -162,18 +162,18 @@ Command line options are provided to select which role a standup should be creat
 To execute, run the following command:
 
 ```bash
-poetry run create-standup { meeting-facilitator | support-steward }
+poetry run create-standup { meeting-facilitator | support-triager }
 ```
 
 **Help info:**
 
 ```bash
-usage: create-standup [-h] {meeting-facilitator,support-steward}
+usage: create-standup [-h] {meeting-facilitator,support-triager}
 
 Create Geekbot standup apps to manage the transition of Team Roles through 2i2c team members
 
 positional arguments:
-  {meeting-facilitator,support-steward}
+  {meeting-facilitator,support-triager}
                         The role to create a Geekbot Standup to transition
 
 optional arguments:
@@ -187,10 +187,10 @@ It depends upon [`get_slack_usergroup_members.py`](#get_slack_usergroup_membersp
 
 This script requires the following environment variables to be set:
 
-- `USERGROUP_NAMES`: The name of the Slack usergroup to list members of, e.g., `meeting-facilitators` or `support-stewards`.
+- `USERGROUP_NAMES`: The name of the Slack usergroup to list members of, e.g., `meeting-facilitators` or `support-triagers`.
   Multiple usergroups can be provided by separating them with a comma.
-- `CURRENT_SUPPORT_STEWARD`: The Slack display name of the team member currently serving in the Support Steward role (i.e. for more than one week)
-- `INCOMING_SUPPORT_STEWARD`: The Slack display name of the team member most recently taking up service in the Support Steward role (i.e. for less than one week)
+- `CURRENT_SUPPORT_TRIAGER`: The Slack display name of the team member currently serving in the Support Triager role (i.e. for more than one week)
+- `INCOMING_SUPPORT_TRIAGER`: The Slack display name of the team member most recently taking up service in the Support Triager role (i.e. for less than one week)
 - `STANDUP_MANAGER`: This is the Slack display name of the team member who created `geekbot_api_token.json` and will be added to all standups.
   This role is required since Geekbot only offers personal API keys and the script won't be able to see any exisitng standups that the owner of the key is not a member of.
   :fire: **If you are changing this role, you will need to recreate `geekbot_api_token.json`.** :fire:
@@ -221,18 +221,18 @@ The desired usergroup is parsed to the script via the `USERGROUP_NAME` environme
 To execute this script, run:
 
 ```bash
-poetry run create-next-event { meeting-facilitator | support-steward }
+poetry run create-next-event { meeting-facilitator | support-triager }
 ```
 
 **Help info:**
 
 ```bash
-usage: create-next-event [-h] {meeting-facilitator,support-steward}
+usage: create-next-event [-h] {meeting-facilitator,support-triager}
 
 Create the next event in a series for a Team Role in a Google Calendar
 
 positional arguments:
-  {meeting-facilitator,support-steward}
+  {meeting-facilitator,support-triager}
                         The role to create an event for
 
 optional arguments:
@@ -246,12 +246,12 @@ It begins generating events either from the day the script is executed or from a
 It depends upon [`get_slack_usergroup_members.py`](#get_slack_usergroup_memberspy) to get an ordered list of the team members who fulfil these roles.
 The desired usergroup is parsed to the script via the `USERGROUP_NAME` environment variable.
 
-#### :fire: Reference Dates for the Support Steward :fire:
+#### :fire: Reference Dates for the Support Triager :fire:
 
-Our Support Steward role starts and ends on Wednesdays for a period of 2 weeks with a team member rotating on/off the role every week.
+Our Support Triager role starts and ends on Wednesdays for a period of 2 weeks with a team member rotating on/off the role every week.
 
 The `create_events_bulk.py` script accounts for this by adjusting the reference date to the next Wednesday in the calendar.
-However, the next Wednesday might not necessarily line up with the 1/2 weekly cycle of the Support Steward.
+However, the next Wednesday might not necessarily line up with the 1/2 weekly cycle of the Support Triager.
 So take caution when running this script and choose a reference date carefully before executing.
 
 The two `create_events_*.py` scripts can't delete events and so, if they are repeatedly run, will create duplicate events.
@@ -262,24 +262,24 @@ See [`delete_events_bulk.py`](#delete_events_bulkpy) for information on deleting
 To execute this script, run:
 
 ```bash
-poetry run create-bulk-events { meeting-facilitator | support-steward }
+poetry run create-bulk-events { meeting-facilitator | support-triager }
 ```
 
 **Help info:**
 
 ```bash
-usage: create-bulk-events [-h] [-n N_EVENTS] [-d DATE] [-m TEAM_MEMBER] {meeting-facilitator,support-steward}
+usage: create-bulk-events [-h] [-n N_EVENTS] [-d DATE] [-m TEAM_MEMBER] {meeting-facilitator,support-triager}
 
 Bulk create a series of Team Role events in a Google Calendar
 
 positional arguments:
-  {meeting-facilitator,support-steward}
+  {meeting-facilitator,support-triager}
                         The role to create events for
 
 options:
   -h, --help            show this help message and exit
   -n N_EVENTS, --n-events N_EVENTS
-                        The number of role events to create. Defaults to 12 for Meeting Facilitator and 26 for Support Steward (both 1 year's worth).
+                        The number of role events to create. Defaults to 12 for Meeting Facilitator and 26 for Support Triager (both 1 year's worth).
   -d DATE, --date DATE  A reference date to begin creating events from. Defaults to appending events from the last in the series, or TODAY if no events exist. WARNING: EXPERIMENTAL
                         FEATURE. This flag is MUTUALLY INCLUSIVE with --team-member [-m].
   -m TEAM_MEMBER, --team-member TEAM_MEMBER
@@ -302,18 +302,18 @@ In the future, we should allow this to be overridden since this script only need
 **Command line usage:**
 
 ```bash
-poetry run delete-bulk-events { meeting-facilitator | support-steward }
+poetry run delete-bulk-events { meeting-facilitator | support-triager }
 ```
 
 **Help info:**
 
 ```bash
-usage: delete-bulk-events [-h] [-d DATE] {meeting-facilitator,support-steward}
+usage: delete-bulk-events [-h] [-d DATE] {meeting-facilitator,support-triager}
 
 Bulk delete all upcoming Team Role events in a Google Calendar
 
 positional arguments:
-  {meeting-facilitator,support-steward}
+  {meeting-facilitator,support-triager}
                         The role to delete events for
 
 options:
@@ -357,13 +357,13 @@ The Geekbot App is configured to notify the next Meeting Facilitator on the firs
 The `update-calendar` job runs the [`create_events_rolling_update.py`](#create_events_rolling_updatepy) script to create the next event in the series, keeping the calendar populated roughly one year in advance.
 If running manually, this job can be skipped completely.
 
-### `support-steward.yaml`
+### `support-triager.yaml`
 
 This workflow file contains two jobs: `create-standup` and `update-calendar`.
 It is scheduled to run at midnight UTC weekly on Mondays and can also be manually triggered using workflow dispatch.
-The Geekbot App is configured to notify the next Support Steward every Wednesday.
+The Geekbot App is configured to notify the next Support Triager every Wednesday.
 
-The `create-standup` job runs the [`create_geekbot_standup.py`](#create_geekbot_standuppy) to update the Support Steward role in the `team-roles.json` file and create/update a Geekbot Standup App to notify the new team member serving in the role.
+The `create-standup` job runs the [`create_geekbot_standup.py`](#create_geekbot_standuppy) to update the Support Triager role in the `team-roles.json` file and create/update a Geekbot Standup App to notify the new team member serving in the role.
 When manually triggered, updating the team roles file is optional, for example if you'd just like to reset the Geekbot App.
 
 The `update-calendar` job runs the [`create_events_rolling_update.py`](#create_events_rolling_updatepy) script to create the next event in the series, keeping the calendar populated roughly one year in advance.

--- a/src/calendar/create_events_bulk.py
+++ b/src/calendar/create_events_bulk.py
@@ -19,7 +19,7 @@ class MutuallyInclusiveArgumentError(Exception):
 
 
 def adjust_reference_date(reference_date):
-    """The Support Steward Role is transferred on Wednesdays. We adjust the reference
+    """The Support Triager Role is transferred on Wednesdays. We adjust the reference
     date to be the next Wednesday from the given date for the calculations.
 
     Args:
@@ -38,7 +38,7 @@ def adjust_reference_date(reference_date):
         reference_date = reference_date + timedelta(days=(7 + (3 - weekday_num)))
 
     logger.info(
-        "Adjusting reference date for Support Steward role to: {}",
+        "Adjusting reference date for Support Triager role to: {}",
         reference_date.strftime("%Y-%m-%d"),
     )
 
@@ -52,7 +52,7 @@ def read_team_roles_from_file(role):
 
     Args:
         role (str): The role we are interested in learning about. Can be either
-            'meeting-facilitator' or 'support-steward'.
+            'meeting-facilitator' or 'support-triager'.
 
     Raises:
         FileNotFoundError: If the file does not exist at the expected location,
@@ -74,7 +74,7 @@ def read_team_roles_from_file(role):
 
     if role == "meeting-facilitator":
         member = team_roles[role.replace("-", "_")]["name"]
-    elif role == "support-steward":
+    elif role == "support-triager":
         member = team_roles[role.replace("-", "_")]["current"]["name"]
 
     return member
@@ -101,7 +101,7 @@ def create_bulk_events(role, n_events=None, ref_date=None, member=None):
 
     if ref_date is not None:
         ref_date = datetime.strptime(ref_date, "%Y-%m-%d")
-        if role == "support-steward":
+        if role == "support-triager":
             ref_date = adjust_reference_date(ref_date)
 
     # Instantiate the event handler
@@ -152,7 +152,7 @@ def create_bulk_events(role, n_events=None, ref_date=None, member=None):
             if role == "meeting-facilitator":
                 ref_date = ref_date.replace(month=ref_date.month + 1)
                 ref_date = ref_date.replace(day=1)
-            elif role == "support-steward":
+            elif role == "support-triager":
                 ref_date = adjust_reference_date(ref_date)
 
             logger.warning(
@@ -188,7 +188,7 @@ def main():
 
     parser.add_argument(
         "role",
-        choices=["meeting-facilitator", "support-steward"],
+        choices=["meeting-facilitator", "support-triager"],
         help="The role to create events for",
     )
     parser.add_argument(
@@ -198,7 +198,7 @@ def main():
         default=None,
         help=(
             "The number of role events to create. "
-            "Defaults to 12 for Meeting Facilitator and 52 for Support Steward (both 1 year's worth)."
+            "Defaults to 12 for Meeting Facilitator and 52 for Support Triager (both 1 year's worth)."
         ),
     )
     parser.add_argument(

--- a/src/calendar/create_events_rolling_update.py
+++ b/src/calendar/create_events_rolling_update.py
@@ -15,7 +15,7 @@ def create_next_event(role):
 
     Args:
         role (str): Which role we wish to create a new event for. Can be either
-            'meeting-facilitator' or 'support-steward'.
+            'meeting-facilitator' or 'support-triager'.
     """
     # Set variables from environment
     ci = os.environ.get("CI", False)
@@ -43,7 +43,7 @@ def main():
     )
     parser.add_argument(
         "role",
-        choices=["meeting-facilitator", "support-steward"],
+        choices=["meeting-facilitator", "support-triager"],
         help="The role to create an event for",
     )
     args = parser.parse_args()

--- a/src/calendar/delete_events_bulk.py
+++ b/src/calendar/delete_events_bulk.py
@@ -20,7 +20,7 @@ def main():
 
     parser.add_argument(
         "role",
-        choices=["meeting-facilitator", "support-steward"],
+        choices=["meeting-facilitator", "support-triager"],
         help="The role to delete events for",
     )
     parser.add_argument(

--- a/src/calendar/event_handling.py
+++ b/src/calendar/event_handling.py
@@ -23,7 +23,7 @@ ROLE_CYCLES = {
         "n_events": 12,  # Equates to 1 year
         "index": 1,  # Index to extract next event from
     },
-    "support-steward": {
+    "support-triager": {
         "unit": "days",
         "frequency": 7,  # Weekly
         "period": 14,  # 2 weeks
@@ -69,7 +69,7 @@ class CalendarEventHandler:
                 Defaults to TODAY in ISO format.
             nMaxResults (int, optional): The maximum number of future events to
                 pull from the calendar. There will be 12 Meeting Facilitator events
-                per year and 26 Support Steward events per year - so 50 is enough
+                per year and 26 Support Triager events per year - so 50 is enough
                 to cover both those event types together, plus some extra.
                 Defaults to 50.
 
@@ -171,7 +171,7 @@ class CalendarEventHandler:
                 months=ROLE_CYCLES[self.role]["period"]
             )
 
-        elif self.role == "support-steward":
+        elif self.role == "support-triager":
             next_event_start_date = event_end_date + relativedelta(
                 days=ROLE_CYCLES[self.role]["frequency"] * offset
             )
@@ -258,8 +258,8 @@ class CalendarEventHandler:
         first_event_end_date = datetime.strptime(first_event_end_date, "%Y-%m-%d")
         first_member = first_event.get("summary", "").split(":")[-1].strip()
 
-        if self.role == "support-steward":
-            # We use [1] here because the support steward role overlaps by 2 two
+        if self.role == "support-triager":
+            # We use [1] here because the support triager role overlaps by 2 two
             # weeks. So for the team member serving in the role, we need to use
             # the next event to calculate where to begin iterating from.
             first_event = self.upcoming_events[1]
@@ -294,8 +294,8 @@ class CalendarEventHandler:
         last_event_end_date = datetime.strptime(last_event_end_date, "%Y-%m-%d")
         last_member = last_event.get("summary", "").split(":")[-1].strip()
 
-        if self.role == "support-steward":
-            # We use [-2] here because the support steward role overlaps itself.
+        if self.role == "support-triager":
+            # We use [-2] here because the support triager role overlaps itself.
             # So for the last event dates, we need the second to last event in
             # the list.
             last_event = self.upcoming_events[-2]
@@ -317,7 +317,7 @@ class CalendarEventHandler:
                 Defaults to TODAY in ISO format.
             nMaxResults (int, optional): The maximum number of future events to
                 pull from the calendar. There will be 12 Meeting Facilitator events
-                per year and 26 Support Steward events per year - so 50 is enough
+                per year and 26 Support Triager events per year - so 50 is enough
                 to cover both those event types together, plus some extra.
                 Defaults to 50.
 

--- a/src/calendar/event_handling.py
+++ b/src/calendar/event_handling.py
@@ -102,12 +102,25 @@ class CalendarEventHandler:
 
         events = events_results.get("items", [])
 
-        # Filter the events for those that have the specified role in their summary
-        events = [
-            event
-            for event in events
-            if " ".join(self.role.split("-")).title() in event["summary"]
-        ]
+        # Filter the events for those that have the specified role in their summary.
+        # We support finding events that have the old role name "Support Steward"
+        # in their summary so that the calendar did not have to be updated at the
+        # time the role switch took place. We should deprecated this if statement
+        # once all the "Support Steward" entries have passed, somewhere around
+        # October 2024.
+        if self.role == "support-triager":
+            events = [
+                event
+                for event in events
+                if (" ".join(self.role.split("-")).title() in event["summary"])
+                or ("Support Steward" in event["summary"])
+            ]
+        else:
+            events = [
+                event
+                for event in events
+                if " ".join(self.role.split("-")).title() in event["summary"]
+            ]
 
         return events
 

--- a/src/geekbot/create_geekbot_standup.py
+++ b/src/geekbot/create_geekbot_standup.py
@@ -145,26 +145,26 @@ class GeekbotStandup:
         )
         return question
 
-    def _generate_question_support_steward(self):
-        """Generate the question that will be asked of the the new Support Steward
+    def _generate_question_support_triager(self):
+        """Generate the question that will be asked of the the new Support Triager
         in the standup. It will be added to the metadata generated in
         _generate_standup_metadata.
 
         Returns:
-            str: The question to be posed to the new Support Steward
+            str: The question to be posed to the new Support Triager
         """
         logger.info(f"Generating question for standup: {self.standup_name}")
 
         question = (
-            f"{self.roles['name'].split()[0]} - it is your turn to be the support steward! "
+            f"{self.roles['name'].split()[0]} - it is your turn to be the support triager! "
             + "Please make sure to watch for any incoming tickets here:\n\n"
             + "https://2i2c.freshdesk.com/a/tickets/filters/all_tickets"
             + "\n\n"
             + "Reply 'ok' to this message to acknowledge your role. "
-            + "Or if you are going to be away for a large part of your stewardship, please arrange cover with another member of the team. "
+            + "Or if you are going to be away for a large part of your rotation, please arrange cover with another member of the team. "
             + "If you have already swapped with someone, please tag them in your response."
             + "\n\n"
-            + f"Your support steward buddy is: {self.steward_buddy.split()[0]}"
+            + f"Your support triager buddy is: {self.triager_buddy.split()[0]}"
         )
         return question
 
@@ -212,17 +212,17 @@ class GeekbotStandup:
 
         response.raise_for_status()
 
-    def create_support_steward_standup(self):
+    def create_support_triager_standup(self):
         """
-        Create a Geekbot standup to transition the Support Steward role
+        Create a Geekbot standup to transition the Support Triager role
         """
         # Set variables
-        self.standup_name = "SupportStewardStandup"
+        self.standup_name = "SupportTriagerStandup"
         self.standup_day = "Wed"
         self.broadcast_channel = "#support-freshdesk"
         self.standup_manager = self.roles["standup_manager"]
-        self.steward_buddy = self.roles["support_steward"]["current"]["name"]
-        self.roles = self.roles["support_steward"]["incoming"]
+        self.triager_buddy = self.roles["support_triager"]["current"]["name"]
+        self.roles = self.roles["support_triager"]["incoming"]
 
         # First, check if a standup exists
         standup_id = self._check_standup_exists()
@@ -231,7 +231,7 @@ class GeekbotStandup:
         metadata = self._generate_standup_metadata()
 
         # Generate the standup question
-        question = self._generate_question_support_steward()
+        question = self._generate_question_support_triager()
         metadata["questions"] = [{"question": question}]
 
         if self.standup_exists:
@@ -267,7 +267,7 @@ def main():
     )
     parser.add_argument(
         "role",
-        choices=["meeting-facilitator", "support-steward"],
+        choices=["meeting-facilitator", "support-triager"],
         help="The role to create a Geekbot Standup to transition",
     )
     args = parser.parse_args()
@@ -278,8 +278,8 @@ def main():
     # Create a standup for the chosen role
     if args.role == "meeting-facilitator":
         standup.create_meeting_facilitator_standup()
-    elif args.role == "support-steward":
-        standup.create_support_steward_standup()
+    elif args.role == "support-triager":
+        standup.create_support_triager_standup()
 
 
 if __name__ == "__main__":

--- a/src/geekbot/set_current_roles.py
+++ b/src/geekbot/set_current_roles.py
@@ -35,8 +35,8 @@ def main():
         raise FileNotFoundError(f"File must exist to continue! {roles_path}")
 
     # Set environment variables
-    current_support_steward = os.environ["CURRENT_SUPPORT_STEWARD"]
-    incoming_support_steward = os.environ["INCOMING_SUPPORT_STEWARD"]
+    current_support_triager = os.environ["CURRENT_SUPPORT_TRIAGER"]
+    incoming_support_triager = os.environ["INCOMING_SUPPORT_TRIAGER"]
     standup_manager = os.environ["STANDUP_MANAGER"]
     current_meeting_facilitator = os.environ.get("CURRENT_MEETING_FACILITATOR", None)
 
@@ -61,7 +61,7 @@ def main():
     team_roles = {
         "standup_manager": {
             "name": standup_manager,
-            "id": members["support-stewards"][standup_manager],
+            "id": members["support-triagers"][standup_manager],
         },
         "meeting_facilitator": {
             "name": current_meeting_facilitator,
@@ -69,14 +69,14 @@ def main():
             if current_meeting_facilitator is None
             else members["meeting-facilitators"][current_meeting_facilitator],
         },
-        "support_steward": {
+        "support_triager": {
             "incoming": {
-                "name": incoming_support_steward,
-                "id": members["support-stewards"][incoming_support_steward],
+                "name": incoming_support_triager,
+                "id": members["support-triagers"][incoming_support_triager],
             },
             "current": {
-                "name": current_support_steward,
-                "id": members["support-stewards"][current_support_steward],
+                "name": current_support_triager,
+                "id": members["support-triagers"][current_support_triager],
             },
         },
     }

--- a/src/geekbot/update_team_roles.py
+++ b/src/geekbot/update_team_roles.py
@@ -66,17 +66,17 @@ class TeamRoles:
         self.team_roles["meeting_facilitator"]["name"] = next_member_name.split(" ")[0]
         self.team_roles["meeting_facilitator"]["id"] = next_member_id
 
-    def _update_support_steward_role(self, next_member_name):
-        """Update the Support Steward role metadata"""
+    def _update_support_triager_role(self, next_member_name):
+        """Update the Support Triager role metadata"""
         # The incoming team member becomes the current team member
-        self.team_roles["support_steward"]["current"]["name"] = self.team_roles[
-            "support_steward"
+        self.team_roles["support_triager"]["current"]["name"] = self.team_roles[
+            "support_triager"
         ]["incoming"]["name"]
-        self.team_roles["support_steward"]["current"]["id"] = self.team_roles[
-            "support_steward"
+        self.team_roles["support_triager"]["current"]["id"] = self.team_roles[
+            "support_triager"
         ]["incoming"]["id"]
 
-        # Find the ID of the next Support Steward
+        # Find the ID of the next Support Triager
         next_member_id = next(
             (
                 id
@@ -87,10 +87,10 @@ class TeamRoles:
         )
 
         # The next team member is assigned to "incoming"
-        self.team_roles["support_steward"]["incoming"]["name"] = next_member_name.split(
+        self.team_roles["support_triager"]["incoming"]["name"] = next_member_name.split(
             " "
         )[0]
-        self.team_roles["support_steward"]["incoming"]["id"] = next_member_id
+        self.team_roles["support_triager"]["incoming"]["id"] = next_member_id
 
     def update_roles(self):
         """Update our Team Roles by inspecting a Google Calendar and/or iterating
@@ -114,9 +114,9 @@ class TeamRoles:
         if self.role == "meeting-facilitator":
             logger.info("Updating the Meeting Facilitator role")
             self._update_meeting_facilitator_role(next_member)
-        elif self.role == "support-steward":
-            logger.info("Updating the Support Steward role")
-            self._update_support_steward_role(next_member)
+        elif self.role == "support-triager":
+            logger.info("Updating the Support Triager role")
+            self._update_support_triager_role(next_member)
 
         # Write the updated roles to a JSON file
         logger.info("Writing roles to team-roles.json")
@@ -131,7 +131,7 @@ def main():
     )
     parser.add_argument(
         "role",
-        choices=["meeting-facilitator", "support-steward"],
+        choices=["meeting-facilitator", "support-triager"],
         help="The role to update",
     )
     args = parser.parse_args()

--- a/team-roles.json
+++ b/team-roles.json
@@ -7,7 +7,7 @@
         "name": null,
         "id": null
     },
-    "support_steward": {
+    "support_triager": {
         "incoming": {
             "name": "Sarah",
             "id": "U01G3RJP1U3"

--- a/tests/test_calendar/test_event_handling.py
+++ b/tests/test_calendar/test_event_handling.py
@@ -23,17 +23,17 @@ class EventHandlerSubClass(CalendarEventHandler):
             {
                 "start": {"date": "2022-08-24"},
                 "end": {"date": "2022-09-21"},
-                "summary": "Support Steward: Person A",
+                "summary": "Support Triager: Person A",
             },
             {
                 "start": {"date": "2022-09-07"},
                 "end": {"date": "2022-10-05"},
-                "summary": "Support Steward: Person B",
+                "summary": "Support Triager: Person B",
             },
             {
                 "start": {"date": "2022-09-21"},
                 "end": {"date": "2022-10-19"},
-                "summary": "Support Steward: Person C",
+                "summary": "Support Triager: Person C",
             },
         ]
 
@@ -64,10 +64,10 @@ def test_create_next_event_dates_meeting_facilitator_no_offset():
     assert next_end_date == expected_end_date
 
 
-def test_create_next_event_dates_support_steward_no_offset():
+def test_create_next_event_dates_support_triager_no_offset():
     end_date = datetime(2023, 3, 29)
 
-    test_event_handler = EventHandlerSubClass("support-steward", "support-stewards")
+    test_event_handler = EventHandlerSubClass("support-triager", "support-triagers")
     next_start_date, next_end_date = test_event_handler._calculate_next_event_dates(
         end_date, 0
     )
@@ -102,11 +102,11 @@ def test_create_next_event_dates_meeting_facilitator_with_offset():
     case.assertCountEqual(next_event_dates, expected_event_dates)
 
 
-def test_create_next_event_dates_support_steward_with_offset():
+def test_create_next_event_dates_support_triager_with_offset():
     case = unittest.TestCase()
     end_date = datetime(2023, 3, 29)
     offset = 3
-    test_event_handler = EventHandlerSubClass("support-steward", "support-stewards")
+    test_event_handler = EventHandlerSubClass("support-triager", "support-triagers")
 
     next_event_dates = []
     for i in range(offset):
@@ -124,7 +124,7 @@ def test_create_next_event_dates_support_steward_with_offset():
 
 
 def test_find_next_team_member_manually():
-    test_event_handler = EventHandlerSubClass("support-steward", "support-stewards")
+    test_event_handler = EventHandlerSubClass("support-triager", "support-triagers")
     next_member_no_offset = test_event_handler._find_next_team_member_manually(
         "Person B"
     )
@@ -150,8 +150,8 @@ def test_get_last_event_meeting_facilitator():
     assert last_member == "Person B"
 
 
-def test_get_last_event_support_steward():
-    test_event_handler = EventHandlerSubClass("support-steward", "support-stewards")
+def test_get_last_event_support_triager():
+    test_event_handler = EventHandlerSubClass("support-triager", "support-triagers")
     end_date, last_member = test_event_handler._get_last_event(suppress_logs=True)
 
     assert end_date == datetime(2022, 10, 5)
@@ -168,8 +168,8 @@ def test_get_first_event_meeting_facilitator():
     assert last_member == "Person A"
 
 
-def test_get_first_event_support_steward():
-    test_event_handler = EventHandlerSubClass("support-steward", "support-stewards")
+def test_get_first_event_support_triager():
+    test_event_handler = EventHandlerSubClass("support-triager", "support-triagers")
     end_date, last_member = test_event_handler.get_first_event()
 
     assert end_date == datetime(2022, 9, 21)
@@ -185,8 +185,8 @@ def test_find_next_team_member_from_calendar_meeting_facilitator():
     assert next_member == "Person B"
 
 
-def test_find_next_team_member_from_calendar_support_steward():
-    test_event_handler = EventHandlerSubClass("support-steward", "support-stewards")
+def test_find_next_team_member_from_calendar_support_triager():
+    test_event_handler = EventHandlerSubClass("support-triager", "support-triagers")
     next_member = test_event_handler.find_next_team_member_from_calendar()
 
     assert next_member == "Person C"


### PR DESCRIPTION
Todo:

- [x] Update name of Geekbot standup
- [x] Update name of team in Slack
- [ ] Might also need to update the existing calendar entries as well as I believe they filter on role name
  - Addressed by https://github.com/2i2c-org/team-roles-geekbot-sweep/pull/200/commits/5d3b2c88e3abd641ef9569c88bdeadd4ee6dc7a8