### PR TITLE
Group dependabot updates together

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      poetry:
+        patterns:
+          - "*"


### PR DESCRIPTION
Reduce the number of PRs opened and prevents every merged PR updating poetry to cause a conflict with every other open PR.